### PR TITLE
added model_version to the dpr model loading

### DIFF
--- a/src/evaluation/config/retriever_reader_eval_squad_config.py
+++ b/src/evaluation/config/retriever_reader_eval_squad_config.py
@@ -5,7 +5,8 @@ parameters = {
     "k_reader_total": [5],
     "reader_model_version": ["053b085d851196110d7a83d8e0f077d0a18470be"],
     "retriever_model_version": ["1a01b38498875d45f69b2a6721bf6fe87425da39"],
-    "retriever_type": ["sbert"], # Can be bm25, sbert, dpr, title or title_bm25
+    "dpr_model_version": ["latest"],
+    "retriever_type": ["bm25"], # Can be bm25, sbert, dpr, title or title_bm25
     "squad_dataset": ["./clients/cnil/knowledge_base/squad.json"],
     "filter_level": [None],
     "preprocessing": [False],

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -72,6 +72,7 @@ def single_run(idx=None, **kwargs):
         preprocessing = kwargs["preprocessing"]
         reader_model_version = kwargs["reader_model_version"]
         retriever_model_version = kwargs["retriever_model_version"]
+        dpr_model_version = kwargs["dpr_model_version"]
         split_by = kwargs["split_by"]
         split_length = int(kwargs["split_length"])  # this is intended to convert numpy.int64 to int
         title_boosting_factor = kwargs["boosting"]
@@ -172,6 +173,7 @@ def single_run(idx=None, **kwargs):
                 document_store=document_store,
                 query_embedding_model="etalab-ia/dpr-question_encoder-fr_qa-camembert",
                 passage_embedding_model="etalab-ia/dpr-ctx_encoder-fr_qa-camembert",
+                model_version="v1.0",
                 infer_tokenizer_classes=True,
                 use_gpu=GPU_AVAILABLE,
             )
@@ -279,9 +281,6 @@ def single_run(idx=None, **kwargs):
                 {k: v for k, v in retriever_eval_results.items() if v is not None}
             )
             logger.info(f"Run finished successfully")
-            logger.info(
-                f'Reader Accuracy: {retriever_eval_results["reader_topk_accuracy"]}'
-            )
             try:
                 mlflow.log_artifact(f"./logs/root.log")
             except Exception:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -116,6 +116,7 @@ def retriever_dpr(document_store, gpu_available):
     return DensePassageRetriever(document_store=document_store,
                                  query_embedding_model="etalab-ia/dpr-question_encoder-fr_qa-camembert",
                                  passage_embedding_model="etalab-ia/dpr-ctx_encoder-fr_qa-camembert",
+                                 model_version="v1.0",
                                  infer_tokenizer_classes=True,
                                  use_gpu=gpu_available)
 


### PR DESCRIPTION
# What?
This PR solves the Issue https://github.com/etalab-ia/piaf-ml/issues/92.
The problem was that we did not load versioned DPR models while using the `DensePassageRetriever`.

# How it was solved?
I added a tag to the dpr model (both context encoder and query encoder): https://huggingface.co/etalab-ia/dpr-ctx_encoder-fr_qa-camembert/tree/v1.0

We can now specify this tag while loading the model: 