### PR TITLE
Non regression test

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,15 +2,3 @@
 MLFLOW_TRACKING_USERNAME=someusername
 MLFLOW_TRACKING_PASSWORD=somepassword
 MLFLOW_TRACKING_SERVER_URI = https://mlflow.endpoint
-
-# If True, experiments already performed and recorded in mlflow won't be rerun.
-USE_CACHE=False
-
-# Parameter tuning method to use:
-# True: use bayesian optimisation
-# False: use grid search
-USE_OPTIMIZATION=False
-
-# Number of simulations to run when using bayesian optimisation for parameter
-# tuning
-OPTIMIZATION_NCALLS=10

--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ data/vosdroits-latest
 output/
 cached_dense_dicts/
 .env
+
+# Configuration files
+non-regression-tests/known_hosts
+non-regression-tests/.env

--- a/non-regression-tests/.env.template
+++ b/non-regression-tests/.env.template
@@ -1,0 +1,14 @@
+# MLFLOW SSH access
+MLFLOW_SSH_USERNAME=username
+MLFLOW_SSH_HOSTNAME=your.mlflow.hostname
+MLFLOW_SSH_PRIVATE_KEY=~/.ssh/id_rsa
+
+# MLFLOW HTTP access
+MLFLOW_TRACKING_USERNAME=http_login
+MLFLOW_TRACKING_PASSWORD=http_passwd
+MLFLOW_TRACKING_SERVER_URI=https://your.mlflow.hostname/mlflow/
+
+ELASTICSEARCH_HOSTNAME=elasticsearch
+ELASTICSEARCH_PORT=9200
+
+TEST_DATASET=../test/samples/squad/tiny.json

--- a/non-regression-tests/Dockerfile
+++ b/non-regression-tests/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update
 RUN apt-get install --yes git
 RUN git clone https://github.com/etalab-ia/piaf-ml.git
 WORKDIR "/usr/local/src/piaf-ml"
-# TODO AFTERMERGE use main branch
-RUN git checkout non-regression-test
+RUN git checkout master
 
 # Add timezone to prevent tzdata installation from blocking
 # https://dev.to/setevoy/docker-configure-tzdata-and-timezone-during-build-20bk

--- a/non-regression-tests/Dockerfile
+++ b/non-regression-tests/Dockerfile
@@ -1,0 +1,38 @@
+FROM ubuntu:21.04
+WORKDIR "/usr/local/src"
+RUN apt-get update
+RUN apt-get install --yes git
+RUN git clone https://github.com/etalab-ia/piaf-ml.git
+WORKDIR "/usr/local/src/piaf-ml"
+# TODO AFTERMERGE use main branch
+RUN git checkout non-regression-test
+
+# Add timezone to prevent tzdata installation from blocking
+# https://dev.to/setevoy/docker-configure-tzdata-and-timezone-during-build-20bk
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get install --yes gcc make python3-pip python3-dev
+RUN pip install -r requirements.txt
+
+COPY non-regression-tests /usr/local/bin/
+COPY non-regression-tests.py /usr/local/src/non-regression-tests/
+COPY .env /usr/local/src/non-regression-tests/
+COPY crontab /usr/local/src/non-regression-tests/
+
+RUN apt-get install --yes cron
+RUN crontab /usr/local/src/non-regression-tests/crontab
+RUN mkdir -p /var/log/non-regression-tests
+
+ENV HOME=/root
+
+# Configure ssh access to mlflow server
+RUN mkdir -p $HOME/.ssh
+ARG MLFLOW_SSH_USERNAME
+ARG MLFLOW_SSH_HOSTNAME
+RUN echo "Host $MLFLOW_SSH_HOSTNAME\n\
+    User $MLFLOW_SSH_USERNAME" > $HOME/.ssh/config
+RUN ln -s /run/secrets/.ssh/id_rsa $HOME/.ssh/id_rsa
+COPY known_hosts $HOME/.ssh/known_hosts
+
+CMD cron -f

--- a/non-regression-tests/README.md
+++ b/non-regression-tests/README.md
@@ -1,0 +1,10 @@
+This folders is for running non-regression-tests in a scheduled manner.
+
+Usage:
+
+1. Copy the folder to the host that will run the tests.
+2. Copy a test dataset locally.
+2. Copy `.env.template` to `.env` and edit it as needed.
+3. Create the file `known_hosts` and fill it with the mlflow server public key
+   (use ssh-keyscan or connect once manually and copy the content of
+   `~/.ssh/known_hosts`)

--- a/non-regression-tests/README.md
+++ b/non-regression-tests/README.md
@@ -8,3 +8,4 @@ Usage:
 3. Create the file `known_hosts` and fill it with the mlflow server public key
    (use ssh-keyscan or connect once manually and copy the content of
    `~/.ssh/known_hosts`)
+4. Run `docker-compose up -d`

--- a/non-regression-tests/crontab
+++ b/non-regression-tests/crontab
@@ -1,0 +1,1 @@
+* 4 * * * /usr/local/bin/non-regression-tests 2>&1 > /var/log/non-regression-tests/$(date -Iseconds)

--- a/non-regression-tests/docker-compose.yml
+++ b/non-regression-tests/docker-compose.yml
@@ -1,0 +1,28 @@
+version: "3.3"
+services:
+  non-regression-tests:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - MLFLOW_SSH_USERNAME=${MLFLOW_SSH_USERNAME}
+        - MLFLOW_SSH_HOSTNAME=${MLFLOW_SSH_HOSTNAME}
+    depends_on:
+      - elasticsearch
+    secrets:
+      - source: ssh-private-key
+        target: .ssh/id_rsa
+    volumes:
+      - $HOME/.cache/huggingface:/root/.cache/huggingface
+      - ${TEST_DATASET}:/usr/local/share/non-regression-tests/fquad_eval.json
+    env_file: .env
+    restart: always
+  elasticsearch:
+    image: "elasticsearch:7.13.2"
+    environment:
+      - discovery.type=single-node
+    restart: always
+
+secrets:
+  ssh-private-key:
+    file: ${MLFLOW_SSH_PRIVATE_KEY}

--- a/non-regression-tests/non-regression-tests
+++ b/non-regression-tests/non-regression-tests
@@ -28,9 +28,8 @@ echo $$ > $LOCKFILE
 
 cd $PIAF_ML_SRC
 
-# TODO AFTERMERGE use master branch
-git fetch origin non-regression-test
-git reset --hard origin/non-regression-test
+git fetch origin master
+git reset --hard origin/master
 
 # If there is no new commit since last run, don't run.
 LAST_COMMIT_FILE=/var/lib/non-regression-tests/last_commit_run

--- a/non-regression-tests/non-regression-tests
+++ b/non-regression-tests/non-regression-tests
@@ -22,7 +22,6 @@ then
     exit 1
 fi
 
-
 # Write current PID to lockfile
 mkdir -p $(dirname $LOCKFILE)
 echo $$ > $LOCKFILE
@@ -32,6 +31,18 @@ cd $PIAF_ML_SRC
 # TODO AFTERMERGE use master branch
 git fetch origin non-regression-test
 git reset --hard origin/non-regression-test
+
+# If there is no new commit since last run, don't run.
+LAST_COMMIT_FILE=/var/lib/non-regression-tests/last_commit_run
+CURRENT_COMMIT=$(git log -n1 --format=format:"%H")
+if [[ -e $LAST_COMMIT_FILE ]] && [[ $(cat $LAST_COMMIT_FILE) = $CURRENT_COMMIT ]]
+then
+    echo "No new commit since last run. Exiting."
+    exit 0
+fi
+
+mkdir -p $(dirname $LAST_COMMIT_FILE)
+echo $CURRENT_COMMIT > $LAST_COMMIT_FILE
 
 pip install -r requirements.txt
 

--- a/non-regression-tests/non-regression-tests
+++ b/non-regression-tests/non-regression-tests
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Strict shell: crash if anything goes wrong
+set -euo pipefail
+
+PIAF_ML_SRC=/usr/local/src/piaf-ml
+NON_REG_TESTS_SRC=/usr/local/src/non-regression-tests
+LOCKFILE=/var/lock/non-regression-tests/.lock
+ENV=$NON_REG_TESTS_SRC/.env
+
+# Manually load and export the required environment variables. Those are wiped
+# out when running via cron.
+set -a
+source $ENV
+set +a
+
+# If already running, exit.
+# If lockfile is present and it contains the PID of a running process, exit
+if [[ -e $LOCKFILE ]] && kill -0 $(cat $LOCKFILE)
+then
+    echo "Another instance of $0 already running with pid $(cat $LOCKFILE). Exiting."
+    exit 1
+fi
+
+
+# Write current PID to lockfile
+mkdir -p $(dirname $LOCKFILE)
+echo $$ > $LOCKFILE
+
+cd $PIAF_ML_SRC
+
+# TODO AFTERMERGE use master branch
+git fetch origin non-regression-test
+git reset --hard origin/non-regression-test
+
+pip install -r requirements.txt
+
+export PYTHONPATH=$PIAF_ML_SRC
+python3 $NON_REG_TESTS_SRC/non-regression-tests.py
+
+rm $LOCKFILE

--- a/non-regression-tests/non-regression-tests.py
+++ b/non-regression-tests/non-regression-tests.py
@@ -10,8 +10,6 @@ from src.evaluation.retriever_reader.retriever_reader_eval_squad import \
 from src.evaluation.config.retriever_reader_eval_squad_config import \
     parameters, parameter_tuning_options
 
-# TODO GPUBRO use default retriever type. This is just for testing
-parameters["retriever_type"] = ["bm25"] # Can be bm25, sbert, dpr, title or title_bm25
 parameters["squad_dataset"] = ["/usr/local/share/non-regression-tests/fquad_eval.json"]
 parameter_tuning_options["experiment_name"] = "non-regression-test"
 

--- a/non-regression-tests/non-regression-tests.py
+++ b/non-regression-tests/non-regression-tests.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+from elasticsearch import Elasticsearch
+import os
+import sys
+import time
+
+from src.evaluation.retriever_reader.retriever_reader_eval_squad import \
+    tune_pipeline
+from src.evaluation.config.retriever_reader_eval_squad_config import \
+    parameters, parameter_tuning_options
+
+# TODO GPUBRO use default retriever type. This is just for testing
+parameters["retriever_type"] = ["bm25"] # Can be bm25, sbert, dpr, title or title_bm25
+parameters["squad_dataset"] = ["/usr/local/share/non-regression-tests/fquad_eval.json"]
+parameter_tuning_options["experiment_name"] = "non-regression-test"
+
+elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME") or "localhost"
+elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT")) or 9200
+
+# Wait for elasticsearch
+timeout = 60 #seconds
+start_wait = time.time()
+
+es = Elasticsearch([f"http://{elasticsearch_hostname}:{elasticsearch_port}/"], verify_certs=True)
+while not es.ping():
+    print(f"Waiting for Elasticsearch to be ready at " \
+        + f"http://{elasticsearch_hostname}:{elasticsearch_port}")
+    sys.stdout.flush()
+    time.sleep(1)
+    if time.time() - start_wait > timeout:
+        print("Timeout waiting for Elasticsearch at " \
+            + "http://{elasticsearch_hostname}:{elasticsearch_port}. " \
+            + "Elasticsearch not found.")
+
+tune_pipeline(
+    parameters,
+    parameter_tuning_options,
+    elasticsearch_hostname = elasticsearch_hostname,
+    elasticsearch_port = elasticsearch_port)

--- a/src/data/evaluation_datasets/treat_questions.py
+++ b/src/data/evaluation_datasets/treat_questions.py
@@ -17,7 +17,8 @@ print("loading completed !")
 
 def remove_tags(line, tag_name):
     """
-    :param line: the line from the xlm file :param tag_name: the name of the tag you want to remove :return: string
+    :param line: the line from the xlm file 
+    :param tag_name: the name of the tag you want to remove :return: string
     without the xml tags
     """
     return line.replace(f"<{tag_name}>", "").replace(f"</{tag_name}>", "")

--- a/src/data/knowledge_base/prepare_spf_kbase.py
+++ b/src/data/knowledge_base/prepare_spf_kbase.py
@@ -276,10 +276,11 @@ def try_get_situation_text(
     The chapitres text are apparently in the first children level of the Chapitre as a Paragraphe(s). So the idea here
     is to grab all the paragraphs that occur before anything else (a BlocCas p. ex) and consider it as the chapitre text
     (all the text that comes before the Cases) Given that all text (apparently) appears in Paragraphe tags even if they
-    are within Lists, so we remove the Titre and BlocCas to avoid these texts :param list_tags_to_remove: we want to
-    keep all the paragraphs except those inside Titre and BlocCas, so we pop them
+    are within Lists, so we remove the Titre and BlocCas to avoid these texts 
 
-    :param child: :return:
+    :param list_tags_to_remove: we want to keep all the paragraphs except those inside Titre and BlocCas, so we pop them
+    :param child: 
+    :return:
     """
     situation_children = list([t for t in child])
     tags = [t.tag for t in situation_children]
@@ -333,7 +334,10 @@ def try_get_chapitre_text(
     The chapitres text are apparently in the first children level of the Chapitre as a Paragraphe(s). So the idea here
     is to grab all the paragraphs that occur before anything else (a BlocCas p. ex) and consider it as the chapitre text
     (all the text that comes before the Cases) Given that all text (apparently) appears in Paragraphe tags even if they
-    are within Lists, so we remove the Titre and BlocCas to avoid these texts :param list_tags_to_remove: :param child:
+    are within Lists, so we remove the Titre and BlocCas to avoid these texts 
+
+    :param list_tags_to_remove: 
+    :param child:
     :return:
     """
     chapitre_children = list([t for t in child])
@@ -393,7 +397,10 @@ def treat_no_situation_fiche(root: Element):
 
 def clean_elements(root: Element):
     """
-    Keep the interesting bits of the XML (and hence the essential text of the fiche) :param root: :return:
+    Keep the interesting bits of the XML (and hence the essential text of the fiche) 
+
+    :param root: 
+    :return:
     """
     tags = [t for t in list(root)]
     tag_names = [t.tag for t in tags]

--- a/src/evaluation/config/retriever_reader_eval_squad_config.py
+++ b/src/evaluation/config/retriever_reader_eval_squad_config.py
@@ -13,9 +13,24 @@ parameters = {
     "boosting" : [1], #default to 1
     "split_by": ["word"],  # Can be "word", "sentence", or "passage"
     "split_length": [1000],
-    "experiment_name": ["DILA_fullspfV1"]
 }
 # rules:
 # corpus and retriever type requires reloading ES indexing
 # filtering requires >v10
 #
+
+parameter_tuning_options = {
+    # "experiment_name": "DILA_fullspfV1",
+    "experiment_name": "test",
+
+    # Tuning method alternatives:
+    # - "optimization": use bayesian optimisation
+    # - "grid_search"
+    "tuning_method": "grid_search",
+
+    # Additionnal options for the grid search method
+    "use_cache": False,
+
+    # Additionnal options for the optimization method
+    "optimization_ncalls": 10,
+}

--- a/src/evaluation/retriever/retriever_eval.py
+++ b/src/evaluation/retriever/retriever_eval.py
@@ -46,8 +46,10 @@ def load_25k_test_set(test_corpus_path: str):
     """
     Loads the 25k dataset. The 25k dataset is a csv that must contain the url columns (url, url2, url3, url4) and a
     question column. The former contains the list of proposed fiches' URLs and the latter contains the question sent by
-    an user. :param corpus_path: Path of the file containing the 25k corpus :return: Dict with the questions as key and
-    a meta dict as values, the meta dict containing urls where the answer is and the arborescence of where the answer
+    an user. 
+
+    :param corpus_path: Path of the file containing the 25k corpus 
+    :return: Dict with the questions as key and a meta dict as values, the meta dict containing urls where the answer is and the arborescence of where the answer
     lies
     """
     url_cols = ["url", "url_2", "url_3", "url_4"]
@@ -71,8 +73,10 @@ def compute_retriever_precision(true_fiches, retrieved_results, weight_position=
     and counts how many of them exist in the *true* fiches names
 
 
-    :param retrieved_fiches: :param true_fiches: :param weight_position: Bool indicates if the precision must be
-    calculated with a weighted precision :return:
+    :param retrieved_fiches: 
+    :param true_fiches: 
+    :param weight_position: Bool indicates if the precision must be calculated with a weighted precision 
+    :return:
     """
     retrieved_docs = []
     summed_precision = 0
@@ -108,9 +112,12 @@ def compute_retriever_precision(true_fiches, retrieved_results, weight_position=
 def single_run(parameters):
     """
     Queries ES max_k - min_k times, saving at each step the results in a list. At the end plots the line showing the
-    results obtained. For now we can only vary k. :param min_k: Minimum retriever-k to test :param max_k: Maximum
-    retriever-k to test :param weighted_precision: Whether to take into account the position of the retrieved result in
-    the accuracy computation :return:
+    results obtained. For now we can only vary k. 
+
+    :param min_k: Minimum retriever-k to test 
+    :param max_k: Maximum retriever-k to test 
+    :param weighted_precision: Whether to take into account the position of the retrieved result in the accuracy computation 
+    :return:
     """
     # get parameters
     test_corpus_path = Path(parameters["test_dataset"])
@@ -259,8 +266,9 @@ def prepare_ES_mappings(preprocessing: bool, analyzer_config: Dict[str, Dict]):
     """
     The ES preprocessor analyser is set by default. If we do not want it, we have to remove it from our mappings
 
-    :param analyzer_config: Configuration to use for the ES preprocessor analyzer :param preprocessing: Whether to use
-    preprocessing or not :return: None
+    :param analyzer_config: Configuration to use for the ES preprocessor analyzer 
+    :param preprocessing: Whether to use preprocessing or not 
+    :return: None
     """
     list_mappings = [SBERT_MAPPING, DPR_MAPPING, SPARSE_MAPPING]
     for mapping in list_mappings:
@@ -274,10 +282,13 @@ def load_retriever(
     use_cache=False,
 ):
     """
-    Loads ES if needed and indexes the knowledge_base corpus :param use_cache: Whether to use or not stored embeddings
-    cache (if available) :param preprocessing: Boolean that indicates whether we perform preprocessing or not :param
-    knowledge_base_path: PAth of the folder containing the knowledge_base corpus :param retriever_type: The type of
-    retriever to be used :return: A Retriever object ready to be queried
+    Loads ES if needed and indexes the knowledge_base corpus 
+
+    :param use_cache: Whether to use or not stored embeddings cache (if available) 
+    :param preprocessing: Boolean that indicates whether we perform preprocessing or not 
+    :param knowledge_base_path: PAth of the folder containing the knowledge_base corpus 
+    :param retriever_type: The type of retriever to be used 
+    :return: A Retriever object ready to be queried
     """
     knowledge_base_path = Path(knowledge_base_path)
     if not knowledge_base_path.exists():
@@ -434,11 +445,14 @@ def compute_score(
     """
     Given a Retriever to query and its parameters and a test dataset (couple query->true related doc), computes the
     number of matches found by the Retriever. A match is succesful if the retrieved document is among the true related
-    doc of the test set. :param retriever: A Retriever object :param retriever_top_k: The number of docs to retrieve
-    :param test_dataset: A collection of "query":[relevant_doc_1, relevant_doc_2, ...] :param weight_position: Whether
-    to take into account the position of the retrieved result in the accuracy computation :param filter_level: The name
-    of the filter requested, usually the level from the arborescence : 'theme', 'dossier' .. :return: Returns
-    mean_precision, avg_time, and detailed_results
+    doc of the test set. 
+
+    :param retriever: A Retriever object 
+    :param retriever_top_k: The number of docs to retrieve
+    :param test_dataset: A collection of "query":[relevant_doc_1, relevant_doc_2, ...] 
+    :param weight_position: Whether to take into account the position of the retrieved result in the accuracy computation 
+    :param filter_level: The name of the filter requested, usually the level from the arborescence : 'theme', 'dossier' .. 
+    :return: Returns mean_precision, avg_time, and detailed_results
     """
     summed_precision = 0
     found_fiche = 0

--- a/src/evaluation/retriever/retriever_eval_squad.py
+++ b/src/evaluation/retriever/retriever_eval_squad.py
@@ -23,8 +23,10 @@ from src.evaluation.utils.utils_eval import eval_retriever, save_results
 
 def single_run(parameters):
     """
-    Runs a grid search config :param parameters: A dict with diverse config options :return: A dict with the results
-    obtained running the experiment with these parameters
+    Runs a grid search config 
+
+    :param parameters: A dict with diverse config options 
+    :return: A dict with the results obtained running the experiment with these parameters
     """
     # col names
     evaluation_data = Path(parameters["squad_dataset"])

--- a/src/evaluation/retriever/title_qa_pipeline_eval.py
+++ b/src/evaluation/retriever/title_qa_pipeline_eval.py
@@ -21,8 +21,10 @@ from src.evaluation.utils.utils_eval import eval_titleQA_pipeline, save_results
 
 def single_run(parameters):
     """
-    Runs a grid search config :param parameters: A dict with diverse config options :return: A dict with the results
-    obtained running the experiment with these parameters
+    Runs a grid search config 
+
+    :param parameters: A dict with diverse config options 
+    :return: A dict with the results obtained running the experiment with these parameters
     """
     # col names
     evaluation_data = Path(parameters["squad_dataset"])

--- a/src/evaluation/utils/custom_pipelines.py
+++ b/src/evaluation/utils/custom_pipelines.py
@@ -63,8 +63,10 @@ class TitleBM25QAPipeline(BaseStandardPipeline):
             - An ElasticsearchRetriever
         The output of the two retrievers are concatenated based on the number of k_retriever passed for each retrievers.
 
-        :param reader: Reader instance :param retriever: Retriever instance :param k_title_retriever: int :param
-        k_bm25_retriever: int
+        :param reader: Reader instance 
+        :param retriever: Retriever instance 
+        :param k_title_retriever: int 
+        :param k_bm25_retriever: int
         """
         self.k_title_retriever = k_title_retriever
         self.k_bm25_retriever = k_bm25_retriever

--- a/src/evaluation/utils/elasticsearch_management.py
+++ b/src/evaluation/utils/elasticsearch_management.py
@@ -5,15 +5,15 @@ import time
 
 from elasticsearch import Elasticsearch
 
-port = "9200"
 
 
 
-def launch_ES():
+
+def launch_ES(hostname = "localhost", port = "9200"):
     logging.info("Search for Elasticsearch ...")
-    es = Elasticsearch([f"http://localhost:{port}/"], verify_certs=True)
+    es = Elasticsearch([f"http://{hostname}:{port}/"], verify_certs=True)
     if not es.ping():
-        logging.info("Elasticsearch not found !")
+        logging.info(f"Elasticsearch not found at http://{hostname}:{port}!")
         logging.info("Starting Elasticsearch ...")
         if platform.system() == "Windows":
             status = subprocess.run(
@@ -33,9 +33,9 @@ def launch_ES():
         logging.info("Elasticsearch found !")
 
 
-def delete_indices(index="document"):
+def delete_indices(hostname = "localhost", port = "9200", index="document"):
     logging.info(f"Delete index {index} inside Elasticsearch ...")
-    es = Elasticsearch([f"http://localhost:{port}/"], verify_certs=True)
+    es = Elasticsearch([f"http://{hostname}:{port}/"], verify_certs=True)
     es.indices.delete(index=index, ignore=[400, 404])
 
 

--- a/src/evaluation/utils/mlflow_management.py
+++ b/src/evaluation/utils/mlflow_management.py
@@ -49,8 +49,10 @@ def hash_piaf_code():
 
 def get_list_past_run(client, experiment_name):
     """
-    This function returns the list of the past experiments :param client: the mlflow client :param experiment_name: the
-    name of the experiment :return: the list of the past experiments
+    This function returns the list of the past experiments 
+    :param client: the mlflow client 
+    :param experiment_name: the name of the experiment 
+    :return: the list of the past experiments
     """
     try:
         experiment_id = client.get_experiment_by_name(experiment_name).experiment_id
@@ -72,8 +74,8 @@ def create_run_ids(parameters_grid):
     for the git commit of the code, the hash for the knowledge_base being used for testing, the hash for the params of
     the run.
 
-    :param parameters_grid: the parameter grid created from the configuration file :return: the run_ids: a list of run
-    ids
+    :param parameters_grid: the parameter grid created from the configuration file 
+    :return: the run_ids: a list of run ids
     """
     git_commit = subprocess.check_output(
         "git rev-parse --short HEAD", encoding="utf-8", shell=True

--- a/src/evaluation/utils/preprocess.py
+++ b/src/evaluation/utils/preprocess.py
@@ -15,9 +15,10 @@ def add_eval_data_from_file(
     Read Documents + Labels from a SQuAD-style file. Document and Labels can then be indexed to the DocumentStore and be
     used for evaluation.
 
-    :param retriever_emb: the dense retriever to embed the text :param filename: Path to file in SQuAD format :param
-    max_docs: This sets the number of documents that will be loaded. By default, this is set to None, thus reading in
-    all available eval documents. :return: (List of Documents, List of Labels)
+    :param retriever_emb: the dense retriever to embed the text 
+    :param filename: Path to file in SQuAD format 
+    :param max_docs: This sets the number of documents that will be loaded. By default, this is set to None, thus reading in all available eval documents. 
+    :return: (List of Documents, List of Labels)
     """
 
     docs: List[Document] = []

--- a/src/evaluation/utils/utils_eval.py
+++ b/src/evaluation/utils/utils_eval.py
@@ -139,10 +139,11 @@ def eval_retriever_reader(
           - "f1": Average overlap between predicted answers and their corresponding correct answers
           - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
-    :param pipeline: :param document_store: DocumentStore containing the evaluation documents :param device: The device
-    on which the tensors should be processed. Choose from "cpu" and "cuda". :param label_index: Index/Table name where
-    labeled questions are stored :param doc_index: Index/Table name where documents that are used for evaluation are
-    stored
+    :param pipeline:
+    :param document_store: DocumentStore containing the evaluation documents
+    :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
+    :param label_index: Index/Table name where labeled questions are stored
+    :param doc_index: Index/Table name where documents that are used for evaluation are stored
     """
 
     # extract all questions for evaluation
@@ -519,10 +520,11 @@ def eval_titleQA_pipeline(
           - "f1": Average overlap between predicted answers and their corresponding correct answers
           - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
-    :param label_origin: the label for the correct answers :param k_retriever: the number of answers to retrieve from
-    the TitleQAPipeline :param pipeline: The titleQAPipeline :param document_store: DocumentStore containing the
-    evaluation documents and the embeddings of the titles :param label_index: Index/Table name where labeled questions
-    are stored
+    :param label_origin: the label for the correct answers 
+    :param k_retriever: the number of answers to retrieve from the TitleQAPipeline 
+    :param pipeline: The titleQAPipeline 
+    :param document_store: DocumentStore containing the evaluation documents and the embeddings of the titles 
+    :param label_index: Index/Table name where labeled questions are stored
     """
 
     # extract all questions for evaluation

--- a/src/evaluation/utils/utils_optimizer.py
+++ b/src/evaluation/utils/utils_optimizer.py
@@ -15,8 +15,9 @@ class tqdm_skopt(object):
 
 def create_dimensions_from_parameters(parameters):
     """
-    This function creates dimensions for the scikit optimize experiment :param parameters: config file :return: list of
-    dimensions for scikit optimize
+    This function creates dimensions for the scikit optimize experiment 
+    :param parameters: config file 
+    :return: list of dimensions for scikit optimize
     """
     dim1 = Integer(
         name="k_retriever",


### PR DESCRIPTION
## Reference to a related issue
Targetting #64

## Why is the change needed

## Description of the change

### Changes to pre-existing code

Options that were related to parameter tuning (grid search or optimization method as well) in `.env` or in `src/evaluation/config/retriever_reader_eval_squad_config.py` (experiment name) were moved to a separate dictionary in the latter config file.

Elasticsearch hostname and port was made configurable through environment variables.

Grid search and bayesian optimization tuning method were given there own functions in `src/evaluation/retriever_reader/retriever_reader_eval_squad.py` for clarity.

Moved the main body of the pipeline in `src/evaluation/retriever_reader/retriever_reader_eval_squad.py` to its own function `tune_pipeline` to easily call it from other python files. The main body now calls it.

### Addition of a job to run non-regression tests

The necessary files to run the job were added to `non-regression-tests/`.

The crontab triggers the tests at 4 am everyday.

The script `non-regression-tests/non-regression-tests` is the entrypoint. it pulls the last changes from the github repo and triggers the actual tests (in `non-regression-tests/non-regression-tests.py`) unless there were no new commits since the last tests were run.

The Dockerfile and docker-compose.yml take care of packaging the environment to run the tests.

The file `non-regression-tests/README.md` describes the deployment process: copy the folder to the host that will run the tests,
create the files `non-regression-tests/.env` and `non-regression-tests/known_hosts` and run `docker-compose up -d` to deploy. 

## (Optionnal) Description or justification of specific technical choices that were made

Moving the parameter tuning options to config file was done to facilitate changing those options from a script, as in `non-regression-tests/non-regression-tests.py`.

## @mentions of the persons responsible for reviewing 
