### PR TITLE
feat: reinstall only one client

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -7,6 +7,13 @@ endif
 install:
 	@${ANSIBLE} -u ${PIAF_MACHINE_USER} install.yml
 
+reinstall:
+ifndef PIAF_CLIENT
+	@echo "Specify the PIAF_CLIENT you want to work on"
+	exit 1
+endif
+	@${ANSIBLE} -u ${PIAF_MACHINE_USER} reinstall.yml --extra-vars "client=${PIAF_CLIENT}"
+
 wipe_and_insert_data:
 ifndef PIAF_CLIENT
 	@echo "Specify the PIAF_CLIENT you want to work on"

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -18,6 +18,10 @@ Every deployer should:
 With `make install`, you will install haystack for every client configured in hosts.yml 
 > This is (and must remain) idempotent.
 
+### `PIAF_CLIENT=dila make reinstall`
+With `PIAF_CLIENT=dila make reinstall`, you will install haystack just for this client. 
+It will not change the nginx configuration, so it should **not** be used for a first installation
+> This is (and must remain) idempotent.
 
 ### `PIAF_CLIENT=dila make wipe_and_insert_data`
 

--- a/deployment/reinstall.yml
+++ b/deployment/reinstall.yml
@@ -1,0 +1,4 @@
+---
+- hosts: sandbox
+  roles:
+    - haystack


### PR DESCRIPTION
## Reference to a related issue

#98

## Why is the change needed
To be even faster, sometimes we only want to reinstall one client.

## Description of the change
Uses only the ansible haystack role, on the specified client

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 

@guillim
