### PR TITLE
Non reg test refact

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,15 +2,3 @@
 MLFLOW_TRACKING_USERNAME=someusername
 MLFLOW_TRACKING_PASSWORD=somepassword
 MLFLOW_TRACKING_SERVER_URI = https://mlflow.endpoint
-
-# If True, experiments already performed and recorded in mlflow won't be rerun.
-USE_CACHE=False
-
-# Parameter tuning method to use:
-# True: use bayesian optimisation
-# False: use grid search
-USE_OPTIMIZATION=False
-
-# Number of simulations to run when using bayesian optimisation for parameter
-# tuning
-OPTIMIZATION_NCALLS=10

--- a/.env.template
+++ b/.env.template
@@ -2,3 +2,7 @@
 MLFLOW_TRACKING_USERNAME=someusername
 MLFLOW_TRACKING_PASSWORD=somepassword
 MLFLOW_TRACKING_SERVER_URI = https://mlflow.endpoint
+
+# Elasticsearch address
+ELASTICSEARCH_HOSTNAME=elasticsearch
+ELASTICSEARCH_PORT=9200

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 argopt
 construct
 cython
-farm_haystack==0.8.0
+farm-haystack==0.8.0
 google
 ipywidgets
 jupyter-console

--- a/src/data/evaluation_datasets/treat_questions.py
+++ b/src/data/evaluation_datasets/treat_questions.py
@@ -17,7 +17,8 @@ print("loading completed !")
 
 def remove_tags(line, tag_name):
     """
-    :param line: the line from the xlm file :param tag_name: the name of the tag you want to remove :return: string
+    :param line: the line from the xlm file 
+    :param tag_name: the name of the tag you want to remove :return: string
     without the xml tags
     """
     return line.replace(f"<{tag_name}>", "").replace(f"</{tag_name}>", "")

--- a/src/data/knowledge_base/prepare_spf_kbase.py
+++ b/src/data/knowledge_base/prepare_spf_kbase.py
@@ -276,10 +276,11 @@ def try_get_situation_text(
     The chapitres text are apparently in the first children level of the Chapitre as a Paragraphe(s). So the idea here
     is to grab all the paragraphs that occur before anything else (a BlocCas p. ex) and consider it as the chapitre text
     (all the text that comes before the Cases) Given that all text (apparently) appears in Paragraphe tags even if they
-    are within Lists, so we remove the Titre and BlocCas to avoid these texts :param list_tags_to_remove: we want to
-    keep all the paragraphs except those inside Titre and BlocCas, so we pop them
+    are within Lists, so we remove the Titre and BlocCas to avoid these texts 
 
-    :param child: :return:
+    :param list_tags_to_remove: we want to keep all the paragraphs except those inside Titre and BlocCas, so we pop them
+    :param child: 
+    :return:
     """
     situation_children = list([t for t in child])
     tags = [t.tag for t in situation_children]
@@ -333,7 +334,10 @@ def try_get_chapitre_text(
     The chapitres text are apparently in the first children level of the Chapitre as a Paragraphe(s). So the idea here
     is to grab all the paragraphs that occur before anything else (a BlocCas p. ex) and consider it as the chapitre text
     (all the text that comes before the Cases) Given that all text (apparently) appears in Paragraphe tags even if they
-    are within Lists, so we remove the Titre and BlocCas to avoid these texts :param list_tags_to_remove: :param child:
+    are within Lists, so we remove the Titre and BlocCas to avoid these texts 
+
+    :param list_tags_to_remove: 
+    :param child:
     :return:
     """
     chapitre_children = list([t for t in child])
@@ -393,7 +397,10 @@ def treat_no_situation_fiche(root: Element):
 
 def clean_elements(root: Element):
     """
-    Keep the interesting bits of the XML (and hence the essential text of the fiche) :param root: :return:
+    Keep the interesting bits of the XML (and hence the essential text of the fiche) 
+
+    :param root: 
+    :return:
     """
     tags = [t for t in list(root)]
     tag_names = [t.tag for t in tags]

--- a/src/evaluation/config/retriever_reader_eval_squad_config.py
+++ b/src/evaluation/config/retriever_reader_eval_squad_config.py
@@ -13,9 +13,24 @@ parameters = {
     "boosting" : [1], #default to 1
     "split_by": ["word"],  # Can be "word", "sentence", or "passage"
     "split_length": [1000],
-    "experiment_name": ["DILA_fullspfV1"]
 }
 # rules:
 # corpus and retriever type requires reloading ES indexing
 # filtering requires >v10
 #
+
+parameter_tuning_options = {
+    # "experiment_name": "DILA_fullspfV1",
+    "experiment_name": "test",
+
+    # Tuning method alternatives:
+    # - "optimization": use bayesian optimisation
+    # - "grid_search"
+    "tuning_method": "grid_search",
+
+    # Additionnal options for the grid search method
+    "use_cache": False,
+
+    # Additionnal options for the optimization method
+    "optimization_ncalls": 10,
+}

--- a/src/evaluation/retriever/retriever_eval.py
+++ b/src/evaluation/retriever/retriever_eval.py
@@ -46,8 +46,10 @@ def load_25k_test_set(test_corpus_path: str):
     """
     Loads the 25k dataset. The 25k dataset is a csv that must contain the url columns (url, url2, url3, url4) and a
     question column. The former contains the list of proposed fiches' URLs and the latter contains the question sent by
-    an user. :param corpus_path: Path of the file containing the 25k corpus :return: Dict with the questions as key and
-    a meta dict as values, the meta dict containing urls where the answer is and the arborescence of where the answer
+    an user. 
+
+    :param corpus_path: Path of the file containing the 25k corpus 
+    :return: Dict with the questions as key and a meta dict as values, the meta dict containing urls where the answer is and the arborescence of where the answer
     lies
     """
     url_cols = ["url", "url_2", "url_3", "url_4"]
@@ -71,8 +73,10 @@ def compute_retriever_precision(true_fiches, retrieved_results, weight_position=
     and counts how many of them exist in the *true* fiches names
 
 
-    :param retrieved_fiches: :param true_fiches: :param weight_position: Bool indicates if the precision must be
-    calculated with a weighted precision :return:
+    :param retrieved_fiches: 
+    :param true_fiches: 
+    :param weight_position: Bool indicates if the precision must be calculated with a weighted precision 
+    :return:
     """
     retrieved_docs = []
     summed_precision = 0
@@ -108,9 +112,12 @@ def compute_retriever_precision(true_fiches, retrieved_results, weight_position=
 def single_run(parameters):
     """
     Queries ES max_k - min_k times, saving at each step the results in a list. At the end plots the line showing the
-    results obtained. For now we can only vary k. :param min_k: Minimum retriever-k to test :param max_k: Maximum
-    retriever-k to test :param weighted_precision: Whether to take into account the position of the retrieved result in
-    the accuracy computation :return:
+    results obtained. For now we can only vary k. 
+
+    :param min_k: Minimum retriever-k to test 
+    :param max_k: Maximum retriever-k to test 
+    :param weighted_precision: Whether to take into account the position of the retrieved result in the accuracy computation 
+    :return:
     """
     # get parameters
     test_corpus_path = Path(parameters["test_dataset"])
@@ -259,8 +266,9 @@ def prepare_ES_mappings(preprocessing: bool, analyzer_config: Dict[str, Dict]):
     """
     The ES preprocessor analyser is set by default. If we do not want it, we have to remove it from our mappings
 
-    :param analyzer_config: Configuration to use for the ES preprocessor analyzer :param preprocessing: Whether to use
-    preprocessing or not :return: None
+    :param analyzer_config: Configuration to use for the ES preprocessor analyzer 
+    :param preprocessing: Whether to use preprocessing or not 
+    :return: None
     """
     list_mappings = [SBERT_MAPPING, DPR_MAPPING, SPARSE_MAPPING]
     for mapping in list_mappings:
@@ -274,10 +282,13 @@ def load_retriever(
     use_cache=False,
 ):
     """
-    Loads ES if needed and indexes the knowledge_base corpus :param use_cache: Whether to use or not stored embeddings
-    cache (if available) :param preprocessing: Boolean that indicates whether we perform preprocessing or not :param
-    knowledge_base_path: PAth of the folder containing the knowledge_base corpus :param retriever_type: The type of
-    retriever to be used :return: A Retriever object ready to be queried
+    Loads ES if needed and indexes the knowledge_base corpus 
+
+    :param use_cache: Whether to use or not stored embeddings cache (if available) 
+    :param preprocessing: Boolean that indicates whether we perform preprocessing or not 
+    :param knowledge_base_path: PAth of the folder containing the knowledge_base corpus 
+    :param retriever_type: The type of retriever to be used 
+    :return: A Retriever object ready to be queried
     """
     knowledge_base_path = Path(knowledge_base_path)
     if not knowledge_base_path.exists():
@@ -434,11 +445,14 @@ def compute_score(
     """
     Given a Retriever to query and its parameters and a test dataset (couple query->true related doc), computes the
     number of matches found by the Retriever. A match is succesful if the retrieved document is among the true related
-    doc of the test set. :param retriever: A Retriever object :param retriever_top_k: The number of docs to retrieve
-    :param test_dataset: A collection of "query":[relevant_doc_1, relevant_doc_2, ...] :param weight_position: Whether
-    to take into account the position of the retrieved result in the accuracy computation :param filter_level: The name
-    of the filter requested, usually the level from the arborescence : 'theme', 'dossier' .. :return: Returns
-    mean_precision, avg_time, and detailed_results
+    doc of the test set. 
+
+    :param retriever: A Retriever object 
+    :param retriever_top_k: The number of docs to retrieve
+    :param test_dataset: A collection of "query":[relevant_doc_1, relevant_doc_2, ...] 
+    :param weight_position: Whether to take into account the position of the retrieved result in the accuracy computation 
+    :param filter_level: The name of the filter requested, usually the level from the arborescence : 'theme', 'dossier' .. 
+    :return: Returns mean_precision, avg_time, and detailed_results
     """
     summed_precision = 0
     found_fiche = 0

--- a/src/evaluation/retriever/retriever_eval_squad.py
+++ b/src/evaluation/retriever/retriever_eval_squad.py
@@ -23,8 +23,10 @@ from src.evaluation.utils.utils_eval import eval_retriever, save_results
 
 def single_run(parameters):
     """
-    Runs a grid search config :param parameters: A dict with diverse config options :return: A dict with the results
-    obtained running the experiment with these parameters
+    Runs a grid search config 
+
+    :param parameters: A dict with diverse config options 
+    :return: A dict with the results obtained running the experiment with these parameters
     """
     # col names
     evaluation_data = Path(parameters["squad_dataset"])

--- a/src/evaluation/retriever/title_qa_pipeline_eval.py
+++ b/src/evaluation/retriever/title_qa_pipeline_eval.py
@@ -21,8 +21,10 @@ from src.evaluation.utils.utils_eval import eval_titleQA_pipeline, save_results
 
 def single_run(parameters):
     """
-    Runs a grid search config :param parameters: A dict with diverse config options :return: A dict with the results
-    obtained running the experiment with these parameters
+    Runs a grid search config 
+
+    :param parameters: A dict with diverse config options 
+    :return: A dict with the results obtained running the experiment with these parameters
     """
     # col names
     evaluation_data = Path(parameters["squad_dataset"])

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -5,11 +5,7 @@ from pathlib import Path
 
 import torch
 
-from src.evaluation.utils.logging_management import (clean_log,
-                                                     get_custom_logger)
-
-logger = get_custom_logger(None, root_logger_path=Path("./logs/"), level=logging.INFO)
-
+from src.evaluation.utils.logging_management import clean_log
 import mlflow
 from dotenv import load_dotenv
 from farm.utils import BaseMLLogger, initialize_device_settings
@@ -35,7 +31,8 @@ from src.evaluation.utils.elasticsearch_management import (delete_indices,
 from src.evaluation.utils.mlflow_management import (add_extra_params,
                                                     create_run_ids,
                                                     get_list_past_run,
-                                                    prepare_mlflow_server)
+                                                    prepare_mlflow_server,
+                                                    mlflow_log_run)
 from src.evaluation.utils.TitleEmbeddingRetriever import \
     TitleEmbeddingRetriever
 from src.evaluation.utils.utils_optimizer import (
@@ -64,272 +61,257 @@ def single_run(
     saved in the mlflow instance.
     """
 
-    with mlflow.start_run(run_name=idx) as run:
-        mlflow.log_params(kwargs)
+    # Gather parameters
+    evaluation_data = Path(kwargs["squad_dataset"])
+    retriever_type = kwargs["retriever_type"]
+    k_retriever = kwargs["k_retriever"]
+    k_title_retriever = kwargs["k_title_retriever"]
+    k_reader_per_candidate = kwargs["k_reader_per_candidate"]
+    k_reader_total = kwargs["k_reader_total"]
+    preprocessing = kwargs["preprocessing"]
+    reader_model_version = kwargs["reader_model_version"]
+    retriever_model_version = kwargs["retriever_model_version"]
+    dpr_model_version = kwargs["dpr_model_version"]
+    split_by = kwargs["split_by"]
+    split_length = int(kwargs["split_length"])  # this is intended to convert numpy.int64 to int
+    title_boosting_factor = kwargs["boosting"]
 
-        # Gather parameters
-        evaluation_data = Path(kwargs["squad_dataset"])
-        retriever_type = kwargs["retriever_type"]
-        k_retriever = kwargs["k_retriever"]
-        k_title_retriever = kwargs["k_title_retriever"]
-        k_reader_per_candidate = kwargs["k_reader_per_candidate"]
-        k_reader_total = kwargs["k_reader_total"]
-        preprocessing = kwargs["preprocessing"]
-        reader_model_version = kwargs["reader_model_version"]
-        retriever_model_version = kwargs["retriever_model_version"]
-        dpr_model_version = kwargs["dpr_model_version"]
-        split_by = kwargs["split_by"]
-        split_length = int(kwargs["split_length"])  # this is intended to convert numpy.int64 to int
-        title_boosting_factor = kwargs["boosting"]
+    # indexes for the elastic search
+    doc_index = "document_xp"
+    label_index = "label_xp"
 
-        # indexes for the elastic search
-        doc_index = "document_xp"
-        label_index = "label_xp"
+    # deleted indice for elastic search to make sure mappings are properly passed
+    delete_indices(elasticsearch_hostname, elasticsearch_port, index=doc_index)
+    delete_indices(elasticsearch_hostname, elasticsearch_port, index=label_index)
 
-        # deleted indice for elastic search to make sure mappings are properly passed
-        delete_indices(elasticsearch_hostname, elasticsearch_port, index=doc_index)
-        delete_indices(elasticsearch_hostname, elasticsearch_port, index=label_index)
+    prepare_mapping(
+        mapping=SQUAD_MAPPING,
+        title_boosting_factor=title_boosting_factor,
+        embedding_dimension=768,
+    )
 
-        prepare_mapping(
-            mapping=SQUAD_MAPPING,
-            title_boosting_factor=title_boosting_factor,
-            embedding_dimension=768,
+    if preprocessing:
+        preprocessor = PreProcessor(
+            clean_empty_lines=False,
+            clean_whitespace=False,
+            clean_header_footer=False,
+            split_by=split_by,
+            split_length=split_length,
+            split_overlap=0,  # this must be set to 0 at the date of writting this: 22 01 2021
+            split_respect_sentence_boundary=False,  # the support for this will soon be removed : 29 01 2021
         )
+    else:
+        preprocessor = None
 
-        if preprocessing:
-            preprocessor = PreProcessor(
-                clean_empty_lines=False,
-                clean_whitespace=False,
-                clean_header_footer=False,
-                split_by=split_by,
-                split_length=split_length,
-                split_overlap=0,  # this must be set to 0 at the date of writting this: 22 01 2021
-                split_respect_sentence_boundary=False,  # the support for this will soon be removed : 29 01 2021
-            )
-        else:
-            preprocessor = None
+    reader = TransformersReader(
+        model_name_or_path="etalab-ia/camembert-base-squadFR-fquad-piaf",
+        tokenizer="etalab-ia/camembert-base-squadFR-fquad-piaf",
+        model_version=reader_model_version,
+        use_gpu=gpu_id,
+        top_k_per_candidate=k_reader_per_candidate,
+    )
 
-        reader = TransformersReader(
-            model_name_or_path="etalab-ia/camembert-base-squadFR-fquad-piaf",
-            tokenizer="etalab-ia/camembert-base-squadFR-fquad-piaf",
-            model_version=reader_model_version,
-            use_gpu=gpu_id,
-            top_k_per_candidate=k_reader_per_candidate,
+    eval_retriever = PiafEvalRetriever()
+    eval_reader = PiafEvalReader()
+
+    if retriever_type == "bm25":
+        document_store = ElasticsearchDocumentStore(
+            host=elasticsearch_hostname,
+            port=elasticsearch_port,
+            username="",
+            password="",
+            index=doc_index,
+            search_fields=["name", "text"],
+            create_index=False,
+            embedding_field="emb",
+            scheme="",
+            embedding_dim=768,
+            excluded_meta_data=["emb"],
+            similarity="cosine",
+            custom_mapping=SQUAD_MAPPING,
         )
+        retriever = ElasticsearchRetriever(document_store=document_store)
+        p  = RetrieverReaderEvaluationPipeline(
+                                               reader = reader, 
+                                               retriever = retriever, 
+                                               eval_retriever = eval_retriever, 
+                                               eval_reader = eval_reader
+                                               )
 
-        eval_retriever = PiafEvalRetriever()
-        eval_reader = PiafEvalReader()
-
-        if retriever_type == "bm25":
-            document_store = ElasticsearchDocumentStore(
-                host=elasticsearch_hostname,
-                port=elasticsearch_port,
-                username="",
-                password="",
-                index=doc_index,
-                search_fields=["name", "text"],
-                create_index=False,
-                embedding_field="emb",
-                scheme="",
-                embedding_dim=768,
-                excluded_meta_data=["emb"],
-                similarity="cosine",
-                custom_mapping=SQUAD_MAPPING,
-            )
-            retriever = ElasticsearchRetriever(document_store=document_store)
-            p  = RetrieverReaderEvaluationPipeline(
-                                                   reader = reader, 
-                                                   retriever = retriever, 
-                                                   eval_retriever = eval_retriever, 
-                                                   eval_reader = eval_reader
-                                                   )
-
-        elif retriever_type == "sbert":
-            document_store = ElasticsearchDocumentStore(
-                host=elasticsearch_hostname,
-                port=elasticsearch_port,
-                username="",
-                password="",
-                index=doc_index,
-                search_fields=["name", "text"],
-                create_index=False,
-                embedding_field="emb",
-                embedding_dim=768,
-                excluded_meta_data=["emb"],
-                similarity="cosine",
-                custom_mapping=SQUAD_MAPPING,
-            )
-            retriever = EmbeddingRetriever(
-                document_store=document_store,
-                embedding_model="distilbert-base-multilingual-cased",
-                model_version=retriever_model_version,
-                use_gpu=GPU_AVAILABLE,
-                model_format="transformers",
-                pooling_strategy="reduce_max",
-                emb_extraction_layer=-1,
-            )
-            p  = RetrieverReaderEvaluationPipeline(
-                                                   reader = reader, 
-                                                   retriever = retriever, 
-                                                   eval_retriever = eval_retriever, 
-                                                   eval_reader = eval_reader
-                                                   )
-
-        elif retriever_type == "dpr":
-            document_store = ElasticsearchDocumentStore(
-                host=elasticsearch_hostname,
-                port=elasticsearch_port,
-                username="",
-                password="",
-                index=doc_index,
-                search_fields=["name", "text"],
-                create_index=False,
-                embedding_field="emb",
-                embedding_dim=768,
-                excluded_meta_data=["emb"],
-                similarity='dot_product',
-                custom_mapping=SQUAD_MAPPING,
-            )
-            retriever = DensePassageRetriever(
-                document_store=document_store,
-                query_embedding_model="etalab-ia/dpr-question_encoder-fr_qa-camembert",
-                passage_embedding_model="etalab-ia/dpr-ctx_encoder-fr_qa-camembert",
-                model_version=dpr_model_version,
-                infer_tokenizer_classes=True,
-                use_gpu=GPU_AVAILABLE,
-            )
-            p  = RetrieverReaderEvaluationPipeline(
-                                                   reader = reader, 
-                                                   retriever = retriever, 
-                                                   eval_retriever = eval_retriever, 
-                                                   eval_reader = eval_reader
-                                                   )
-
-        elif retriever_type == "title_bm25":
-            document_store = ElasticsearchDocumentStore(
-                host=elasticsearch_hostname,
-                port=elasticsearch_port,
-                username="",
-                password="",
-                index=doc_index,
-                search_fields=["name", "text"],
-                create_index=False,
-                embedding_field="emb",
-                embedding_dim=768,
-                excluded_meta_data=["emb"],
-                similarity="cosine",
-                custom_mapping=SQUAD_MAPPING,
-            )
-            retriever = TitleEmbeddingRetriever(
-                document_store=document_store,
-                embedding_model="distilbert-base-multilingual-cased",
-                model_version=retriever_model_version,
-                use_gpu=GPU_AVAILABLE,
-                model_format="transformers",
-                pooling_strategy="reduce_max",
-                emb_extraction_layer=-1,
-            )
-            retriever_bm25 = ElasticsearchRetriever(document_store=document_store)
-            p = TitleBM25QAEvaluationPipeline(reader=reader,
-                                              retriever_title=retriever, 
-                                              retriever_bm25=retriever_bm25,
-                                              k_title_retriever=k_title_retriever,
-                                              k_bm25_retriever=k_retriever,
-                                              eval_retriever = eval_retriever,
-                                              eval_reader = eval_reader)
-
-            # used to make sure the p.run method returns enough candidates
-            k_retriever = max(k_retriever, k_title_retriever)
-
-        elif retriever_type == "title":
-            document_store = ElasticsearchDocumentStore(
-                host=elasticsearch_hostname,
-                port=elasticsearch_port,
-                username="",
-                password="",
-                index=doc_index,
-                search_fields=["name", "text"],
-                create_index=False,
-                embedding_field="emb",
-                embedding_dim=768,
-                excluded_meta_data=["emb"],
-                similarity="cosine",
-                custom_mapping=SQUAD_MAPPING,
-            )
-            retriever = TitleEmbeddingRetriever(
-                document_store=document_store,
-                embedding_model="distilbert-base-multilingual-cased",
-                model_version=retriever_model_version,
-                use_gpu=GPU_AVAILABLE,
-                model_format="transformers",
-                pooling_strategy="reduce_max",
-                emb_extraction_layer=-1,
-            )
-            p  = RetrieverReaderEvaluationPipeline(
-                                                   reader = reader, 
-                                                   retriever = retriever, 
-                                                   eval_retriever = eval_retriever, 
-                                                   eval_reader = eval_reader
-                                                   )
-
-        else:
-            logging.error(
-                f"You chose {retriever_type}. Choose one from bm25, sbert, dpr, title_bm25 or title."
-            )
-            raise Exception(f"Wrong retriever type for {retriever_type}.")
-
-        # Add evaluation data to Elasticsearch document store
-        document_store.add_eval_data(
-            evaluation_data.as_posix(),
-            doc_index=doc_index,
-            label_index=label_index,
-            preprocessor=preprocessor,
+    elif retriever_type == "sbert":
+        document_store = ElasticsearchDocumentStore(
+            host=elasticsearch_hostname,
+            port=elasticsearch_port,
+            username="",
+            password="",
+            index=doc_index,
+            search_fields=["name", "text"],
+            create_index=False,
+            embedding_field="emb",
+            embedding_dim=768,
+            excluded_meta_data=["emb"],
+            similarity="cosine",
+            custom_mapping=SQUAD_MAPPING,
         )
+        retriever = EmbeddingRetriever(
+            document_store=document_store,
+            embedding_model="distilbert-base-multilingual-cased",
+            model_version=retriever_model_version,
+            use_gpu=GPU_AVAILABLE,
+            model_format="transformers",
+            pooling_strategy="reduce_max",
+            emb_extraction_layer=-1,
+        )
+        p  = RetrieverReaderEvaluationPipeline(
+                                               reader = reader, 
+                                               retriever = retriever, 
+                                               eval_retriever = eval_retriever, 
+                                               eval_reader = eval_reader
+                                               )
 
-        if retriever_type in ["sbert", "dpr", "title_bm25", "title"]:
-            document_store.update_embeddings(retriever, index=doc_index)
+    elif retriever_type == "dpr":
+        document_store = ElasticsearchDocumentStore(
+            host=elasticsearch_hostname,
+            port=elasticsearch_port,
+            username="",
+            password="",
+            index=doc_index,
+            search_fields=["name", "text"],
+            create_index=False,
+            embedding_field="emb",
+            embedding_dim=768,
+            excluded_meta_data=["emb"],
+            similarity='dot_product',
+            custom_mapping=SQUAD_MAPPING,
+        )
+        retriever = DensePassageRetriever(
+            document_store=document_store,
+            query_embedding_model="etalab-ia/dpr-question_encoder-fr_qa-camembert",
+            passage_embedding_model="etalab-ia/dpr-ctx_encoder-fr_qa-camembert",
+            model_version=dpr_model_version,
+            infer_tokenizer_classes=True,
+            use_gpu=GPU_AVAILABLE,
+        )
+        p  = RetrieverReaderEvaluationPipeline(
+                                               reader = reader, 
+                                               retriever = retriever, 
+                                               eval_retriever = eval_retriever, 
+                                               eval_reader = eval_reader
+                                               )
 
-        retriever_reader_eval_results = {}
-        try:
-            start = time.time()
-            full_eval_retriever_reader(document_store=document_store, 
-                                        pipeline=p,
-                                        k_retriever=k_retriever, 
-                                        k_reader_total=k_reader_total,
-                                        label_index=label_index)
+    elif retriever_type == "title_bm25":
+        document_store = ElasticsearchDocumentStore(
+            host=elasticsearch_hostname,
+            port=elasticsearch_port,
+            username="",
+            password="",
+            index=doc_index,
+            search_fields=["name", "text"],
+            create_index=False,
+            embedding_field="emb",
+            embedding_dim=768,
+            excluded_meta_data=["emb"],
+            similarity="cosine",
+            custom_mapping=SQUAD_MAPPING,
+        )
+        retriever = TitleEmbeddingRetriever(
+            document_store=document_store,
+            embedding_model="distilbert-base-multilingual-cased",
+            model_version=retriever_model_version,
+            use_gpu=GPU_AVAILABLE,
+            model_format="transformers",
+            pooling_strategy="reduce_max",
+            emb_extraction_layer=-1,
+        )
+        retriever_bm25 = ElasticsearchRetriever(document_store=document_store)
+        p = TitleBM25QAEvaluationPipeline(reader=reader,
+                                          retriever_title=retriever, 
+                                          retriever_bm25=retriever_bm25,
+                                          k_title_retriever=k_title_retriever,
+                                          k_bm25_retriever=k_retriever,
+                                          eval_retriever = eval_retriever,
+                                          eval_reader = eval_reader)
 
-            retriever_reader_eval_results.update(eval_retriever.get_metrics())
-            retriever_reader_eval_results.update(eval_reader.get_metrics())
+        # used to make sure the p.run method returns enough candidates
+        k_retriever = max(k_retriever, k_title_retriever)
 
-            end = time.time()
+    elif retriever_type == "title":
+        document_store = ElasticsearchDocumentStore(
+            host=elasticsearch_hostname,
+            port=elasticsearch_port,
+            username="",
+            password="",
+            index=doc_index,
+            search_fields=["name", "text"],
+            create_index=False,
+            embedding_field="emb",
+            embedding_dim=768,
+            excluded_meta_data=["emb"],
+            similarity="cosine",
+            custom_mapping=SQUAD_MAPPING,
+        )
+        retriever = TitleEmbeddingRetriever(
+            document_store=document_store,
+            embedding_model="distilbert-base-multilingual-cased",
+            model_version=retriever_model_version,
+            use_gpu=GPU_AVAILABLE,
+            model_format="transformers",
+            pooling_strategy="reduce_max",
+            emb_extraction_layer=-1,
+        )
+        p  = RetrieverReaderEvaluationPipeline(
+                                               reader = reader, 
+                                               retriever = retriever, 
+                                               eval_retriever = eval_retriever, 
+                                               eval_reader = eval_reader
+                                               )
+
+    else:
+        logging.error(
+            f"You chose {retriever_type}. Choose one from bm25, sbert, dpr, title_bm25 or title."
+        )
+        raise Exception(f"Wrong retriever type for {retriever_type}.")
+
+    # Add evaluation data to Elasticsearch document store
+    document_store.add_eval_data(
+        evaluation_data.as_posix(),
+        doc_index=doc_index,
+        label_index=label_index,
+        preprocessor=preprocessor,
+    )
+
+    if retriever_type in ["sbert", "dpr", "title_bm25", "title"]:
+        document_store.update_embeddings(retriever, index=doc_index)
+
+    retriever_reader_eval_results = {}
+    try:
+        start = time.time()
+        full_eval_retriever_reader(document_store=document_store, 
+                                    pipeline=p,
+                                    k_retriever=k_retriever, 
+                                    k_reader_total=k_reader_total,
+                                    label_index=label_index)
+
+        retriever_reader_eval_results.update(eval_retriever.get_metrics())
+        retriever_reader_eval_results.update(eval_reader.get_metrics())
+
+        end = time.time()
 
 
-            logging.info(f"Retriever Recall: {retriever_reader_eval_results['recall']}")
-            logging.info(f"Retriever Mean Avg Precision: {retriever_reader_eval_results['map']}")
-            logging.info(f"Retriever Mean Reciprocal Rank: {retriever_reader_eval_results['mrr']}")
-            logging.info(f"Reader Accuracy: {retriever_reader_eval_results['reader_topk_accuracy_has_answer']}")
-            logging.info(f"reader_topk_f1: {retriever_reader_eval_results['reader_topk_f1']}")
-            
-            # Log time per label in metrics
-            time_per_label = (end - start) / document_store.get_label_count(
-                index=label_index
-            )
-            retriever_reader_eval_results.update({"time_per_label": time_per_label})
+        logging.info(f"Retriever Recall: {retriever_reader_eval_results['recall']}")
+        logging.info(f"Retriever Mean Avg Precision: {retriever_reader_eval_results['map']}")
+        logging.info(f"Retriever Mean Reciprocal Rank: {retriever_reader_eval_results['mrr']}")
+        logging.info(f"Reader Accuracy: {retriever_reader_eval_results['reader_topk_accuracy_has_answer']}")
+        logging.info(f"reader_topk_f1: {retriever_reader_eval_results['reader_topk_f1']}")
 
-            mlflow.log_metrics(
-                {k: v for k, v in retriever_reader_eval_results.items() if v is not None}
-            )
-            logger.info(f"Run finished successfully")
-            try:
-                mlflow.log_artifact(f"./logs/root.log")
-            except Exception:
-                logger.error(
-                    f"Could not upload log to artifact server. "
-                    f"Still saved in logs/root_complete.log"
-                )
+        # Log time per label in metrics
+        time_per_label = (end - start) / document_store.get_label_count(
+            index=label_index
+        )
+        retriever_reader_eval_results.update({"time_per_label": time_per_label})
 
-        except Exception as e:
-            logging.error(f"Could not run this config: {kwargs}. Error {e}.")
+    except Exception as e:
+        logging.error(f"Could not run this config: {kwargs}. Error {e}.")
 
     return retriever_reader_eval_results
 
@@ -339,14 +321,27 @@ def single_run(
 def optimize(parameters, n_calls, result_file_path, gpu_id = -1,
             elasticsearch_hostname = "localhost",
             elasticsearch_port = 9200):
-
+    """ Returns a list of n_calls tuples [(x1, v1), ...] where the lists xi are
+    the parameter values for each evaluation and the dictionaries vi are the run 
+    results. The parameter values for the successive runs are determined by the 
+    bayesian optimization method gp_minimize.
+    """
+ 
     dimensions = create_dimensions_from_parameters(parameters)
+
+    # TODO: optimize should return a generator rather than a list to be 
+    # consistent with the functions grid_search and tune_pipeline.
+    results = []
 
     @use_named_args(dimensions=dimensions)
     def single_run_optimization(**kwargs):
-        return 1 - single_run(gpu_id = gpu_id, 
+        result = single_run(gpu_id = gpu_id, 
             elasticsearch_hostname = elasticsearch_hostname, 
-            elasticsearch_port = elasticsearch_port, **kwargs)["reader_topk_accuracy_has_answer"]
+            elasticsearch_port = elasticsearch_port, **kwargs)
+
+        results.append((None, kwargs, result))
+
+        return 1 - result["reader_topk_accuracy_has_answer"]
 
     res = gp_minimize(
         single_run_optimization,
@@ -357,12 +352,19 @@ def optimize(parameters, n_calls, result_file_path, gpu_id = -1,
     )
     dump(res, result_file_path, store_objective=True)
 
+    return results
+
 
 
 
 def grid_search(parameters, mlflow_client, experiment_name, use_cache = False,
     result_file_path = Path("./output/results_reader.csv"), gpu_id = -1,
     elasticsearch_hostname = "localhost", elasticsearch_port = 9200):
+    """ Returns a generator of tuples [(id1, x1, v1), ...] where id1 is the run
+    id, the lists xi are the parameter values for each evaluation and the
+    dictionaries vi are the run results. The parameter values for each
+    successive run are determined by a grid search method.
+    """
     parameters_grid = list(ParameterGrid(param_grid=parameters))
     list_run_ids = create_run_ids(parameters_grid)
     list_past_run_names = get_list_past_run(mlflow_client, experiment_name)
@@ -382,25 +384,23 @@ def grid_search(parameters, mlflow_client, experiment_name, use_cache = False,
             )
             # Log again run with previous results
             previous_metrics = mlflow_client.get_run(list_past_run_names[idx]).data.metrics
-            with mlflow.start_run(run_name=idx) as run:
 
-                mlflow.log_params(param)
-                mlflow.log_metrics(previous_metrics)
+            yield (idx, param, previous_metrics)
 
         else:  # run notalready done or USE_CACHE set to False or not set
             logging.info(f"Doing run with config : {param}")
-            run_results = single_run(idx = idx, gpu_id = gpu_id, 
-                elasticsearch_hostname = elasticsearch_hostname, 
+            run_results = single_run(idx = idx, gpu_id = gpu_id,
+                elasticsearch_hostname = elasticsearch_hostname,
                 elasticsearch_port = elasticsearch_port, **param)
 
             # For debugging purpose, we keep a copy of the results in a csv form
-            run_results.update(param)
+            save_results(result_file_path=result_file_path,
+                    results_list={**run_results, **param})
 
-            save_results(result_file_path=result_file_path, results_list=run_results)
-
-            clean_log()
             # update list of past experiments
             list_past_run_names = get_list_past_run(mlflow_client, experiment_name)
+
+            yield (idx, param, run_results)
 
 
 
@@ -413,10 +413,13 @@ def tune_pipeline(
     """
     Run the parameter tuning method for the whole pipeline based on the
     parameters.
+
+    Returns a generator of tuples (x1, v1), ... where the dicts xi are the
+    parameters and v1 are the results for each run.
     """
 
-    logger.info("\n---- Parameters ----\n" + pprint.pformat(parameters))
-    logger.info("\n---- Parameter tuning options ----\n" + pprint.pformat(parameter_tuning_options))
+    logging.info("\n---- Parameters ----\n" + pprint.pformat(parameters))
+    logging.info("\n---- Parameter tuning options ----\n" + pprint.pformat(parameter_tuning_options))
 
     experiment_name = parameter_tuning_options["experiment_name"]
     device, n_gpu = initialize_device_settings(use_cuda=True)
@@ -427,14 +430,12 @@ def tune_pipeline(
     else:
         gpu_id = -1
 
-    all_results = []
-
     launch_ES(elasticsearch_hostname, elasticsearch_port)
     client = MlflowClient()
     mlflow.set_experiment(experiment_name=experiment_name)
 
     if parameter_tuning_options["tuning_method"] == "optimization":
-        optimize(
+        runs = optimize(
             parameters = parameters,
             n_calls = parameter_tuning_options["optimization_ncalls"],
             result_file_path = Path("./output/optimize_result.z"),
@@ -443,7 +444,7 @@ def tune_pipeline(
             elasticsearch_port = elasticsearch_port)
 
     elif parameter_tuning_options["tuning_method"] == "grid_search":
-        grid_search(
+        runs = grid_search(
             parameters = parameters,
             mlflow_client = client,
             experiment_name = parameter_tuning_options["experiment_name"],
@@ -459,6 +460,9 @@ def tune_pipeline(
             file = sys.stderr)
         exit(1)
 
+    return runs
+
+
 
 
 
@@ -466,8 +470,13 @@ if __name__ == "__main__":
     from src.evaluation.config.retriever_reader_eval_squad_config import \
             parameters, parameter_tuning_options
 
-    tune_pipeline(
+    runs = tune_pipeline(
         parameters,
         parameter_tuning_options,
         elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME") or "localhost",
         elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT")) or 9200)
+
+    for (run_id, params, results) in runs:
+        clean_log()
+        mlflow_log_run(params, results, idx=run_id)
+ 

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -22,21 +22,18 @@ from skopt.utils import use_named_args
 import sys
 from tqdm import tqdm
 
-from src.evaluation.utils.utils_eval import save_results,full_eval_retriever_reader,PiafEvalRetriever,PiafEvalReader
-from src.evaluation.utils.custom_pipelines import RetrieverReaderEvaluationPipeline,TitleBM25QAEvaluationPipeline
+from src.evaluation.utils.utils_eval import save_results, \
+    full_eval_retriever_reader, PiafEvalRetriever,PiafEvalReader
+from src.evaluation.utils.custom_pipelines import \
+    RetrieverReaderEvaluationPipeline, TitleBM25QAEvaluationPipeline
 from src.evaluation.config.elasticsearch_mappings import SQUAD_MAPPING
-from src.evaluation.utils.elasticsearch_management import (delete_indices,
-                                                           launch_ES,
-                                                           prepare_mapping)
-from src.evaluation.utils.mlflow_management import (add_extra_params,
-                                                    create_run_ids,
-                                                    get_list_past_run,
-                                                    prepare_mlflow_server,
-                                                    mlflow_log_run)
-from src.evaluation.utils.TitleEmbeddingRetriever import \
-    TitleEmbeddingRetriever
-from src.evaluation.utils.utils_optimizer import (
-    LoggingCallback, create_dimensions_from_parameters)
+from src.evaluation.utils.elasticsearch_management import delete_indices, \
+   launch_ES, prepare_mapping
+from src.evaluation.utils.mlflow_management import add_extra_params, \
+    create_run_ids, get_list_past_run, prepare_mlflow_server, mlflow_log_run
+from src.evaluation.utils.TitleEmbeddingRetriever import TitleEmbeddingRetriever
+from src.evaluation.utils.utils_optimizer import LoggingCallback, \
+    create_dimensions_from_parameters
 
 BaseMLLogger.disable_logging = True
 load_dotenv()

--- a/src/evaluation/utils/custom_pipelines.py
+++ b/src/evaluation/utils/custom_pipelines.py
@@ -63,8 +63,10 @@ class TitleBM25QAPipeline(BaseStandardPipeline):
             - An ElasticsearchRetriever
         The output of the two retrievers are concatenated based on the number of k_retriever passed for each retrievers.
 
-        :param reader: Reader instance :param retriever: Retriever instance :param k_title_retriever: int :param
-        k_bm25_retriever: int
+        :param reader: Reader instance 
+        :param retriever: Retriever instance 
+        :param k_title_retriever: int 
+        :param k_bm25_retriever: int
         """
         self.k_title_retriever = k_title_retriever
         self.k_bm25_retriever = k_bm25_retriever

--- a/src/evaluation/utils/elasticsearch_management.py
+++ b/src/evaluation/utils/elasticsearch_management.py
@@ -8,7 +8,6 @@ from elasticsearch import Elasticsearch
 
 
 
-
 def launch_ES(hostname = "localhost", port = "9200"):
     logging.info("Search for Elasticsearch ...")
     es = Elasticsearch([f"http://{hostname}:{port}/"], verify_certs=True)
@@ -30,7 +29,7 @@ def launch_ES(hostname = "localhost", port = "9200"):
         if status.returncode:
             raise Exception("Failed to launch Elasticsearch.")
     else:
-        logging.info("Elasticsearch found !")
+        logging.info(f"Elasticsearch found at http://{hostname}:{port}")
 
 
 def delete_indices(hostname = "localhost", port = "9200", index="document"):

--- a/src/evaluation/utils/elasticsearch_management.py
+++ b/src/evaluation/utils/elasticsearch_management.py
@@ -5,15 +5,15 @@ import time
 
 from elasticsearch import Elasticsearch
 
-port = "9200"
 
 
 
-def launch_ES():
+
+def launch_ES(hostname = "localhost", port = "9200"):
     logging.info("Search for Elasticsearch ...")
-    es = Elasticsearch([f"http://localhost:{port}/"], verify_certs=True)
+    es = Elasticsearch([f"http://{hostname}:{port}/"], verify_certs=True)
     if not es.ping():
-        logging.info("Elasticsearch not found !")
+        logging.info(f"Elasticsearch not found at http://{hostname}:{port}!")
         logging.info("Starting Elasticsearch ...")
         if platform.system() == "Windows":
             status = subprocess.run(
@@ -33,9 +33,9 @@ def launch_ES():
         logging.info("Elasticsearch found !")
 
 
-def delete_indices(index="document"):
+def delete_indices(hostname = "localhost", port = "9200", index="document"):
     logging.info(f"Delete index {index} inside Elasticsearch ...")
-    es = Elasticsearch([f"http://localhost:{port}/"], verify_certs=True)
+    es = Elasticsearch([f"http://{hostname}:{port}/"], verify_certs=True)
     es.indices.delete(index=index, ignore=[400, 404])
 
 

--- a/src/evaluation/utils/logging_management.py
+++ b/src/evaluation/utils/logging_management.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 from typing import Union
 
-
 def clean_log(log_name: str = "root"):
     open(f"./logs/{log_name}.log", "w").close()
 
@@ -47,3 +46,6 @@ def get_custom_logger(
     logger.addHandler(console_handler)
 
     return logger
+
+logger = get_custom_logger(None, root_logger_path=Path("./logs/"), level=logging.INFO)
+

--- a/src/evaluation/utils/mlflow_management.py
+++ b/src/evaluation/utils/mlflow_management.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import mlflow
 from dotenv import load_dotenv
 from tqdm import tqdm
+from src.evaluation.utils.logging_management import logger
 
 load_dotenv()
 
@@ -122,3 +123,23 @@ def prepare_mlflow_server():
     except Exception as e:
         tqdm.write(f"Not using remote tracking servers. Error {e}")
         tqdm.write(f"MLflow tracking to local mlruns folder")
+
+def mlflow_log_run(
+        params,
+        retriever_reader_eval_results,
+        idx=None,
+        root_log_path="./logs/root.log",
+        ):
+    with mlflow.start_run(run_name=idx) as run:
+        mlflow.log_params(params)
+        mlflow.log_metrics(
+            {k: v for k, v in retriever_reader_eval_results.items() if v is not None}
+        )
+        logger.info(f"Run finished successfully")
+        try:
+            mlflow.log_artifact(root_log_path)
+        except Exception:
+            logger.error(
+                f"Could not upload log to artifact server. "
+                f"Still saved in logs/root_complete.log"
+            )

--- a/src/evaluation/utils/mlflow_management.py
+++ b/src/evaluation/utils/mlflow_management.py
@@ -49,8 +49,10 @@ def hash_piaf_code():
 
 def get_list_past_run(client, experiment_name):
     """
-    This function returns the list of the past experiments :param client: the mlflow client :param experiment_name: the
-    name of the experiment :return: the list of the past experiments
+    This function returns the list of the past experiments 
+    :param client: the mlflow client 
+    :param experiment_name: the name of the experiment 
+    :return: the list of the past experiments
     """
     try:
         experiment_id = client.get_experiment_by_name(experiment_name).experiment_id
@@ -72,8 +74,8 @@ def create_run_ids(parameters_grid):
     for the git commit of the code, the hash for the knowledge_base being used for testing, the hash for the params of
     the run.
 
-    :param parameters_grid: the parameter grid created from the configuration file :return: the run_ids: a list of run
-    ids
+    :param parameters_grid: the parameter grid created from the configuration file 
+    :return: the run_ids: a list of run ids
     """
     git_commit = subprocess.check_output(
         "git rev-parse --short HEAD", encoding="utf-8", shell=True

--- a/src/evaluation/utils/mlflow_management.py
+++ b/src/evaluation/utils/mlflow_management.py
@@ -129,12 +129,15 @@ def mlflow_log_run(
         retriever_reader_eval_results,
         idx=None,
         root_log_path="./logs/root.log",
+        pass_criteria=None,
         ):
     with mlflow.start_run(run_name=idx) as run:
         mlflow.log_params(params)
         mlflow.log_metrics(
             {k: v for k, v in retriever_reader_eval_results.items() if v is not None}
         )
+        if pass_criteria != None:
+            mlflow.set_tag("pass_criteria", pass_criteria)
         logger.info(f"Run finished successfully")
         try:
             mlflow.log_artifact(root_log_path)

--- a/src/evaluation/utils/preprocess.py
+++ b/src/evaluation/utils/preprocess.py
@@ -15,9 +15,10 @@ def add_eval_data_from_file(
     Read Documents + Labels from a SQuAD-style file. Document and Labels can then be indexed to the DocumentStore and be
     used for evaluation.
 
-    :param retriever_emb: the dense retriever to embed the text :param filename: Path to file in SQuAD format :param
-    max_docs: This sets the number of documents that will be loaded. By default, this is set to None, thus reading in
-    all available eval documents. :return: (List of Documents, List of Labels)
+    :param retriever_emb: the dense retriever to embed the text 
+    :param filename: Path to file in SQuAD format 
+    :param max_docs: This sets the number of documents that will be loaded. By default, this is set to None, thus reading in all available eval documents. 
+    :return: (List of Documents, List of Labels)
     """
 
     docs: List[Document] = []

--- a/src/evaluation/utils/utils_eval.py
+++ b/src/evaluation/utils/utils_eval.py
@@ -139,10 +139,11 @@ def eval_retriever_reader(
           - "f1": Average overlap between predicted answers and their corresponding correct answers
           - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
-    :param pipeline: :param document_store: DocumentStore containing the evaluation documents :param device: The device
-    on which the tensors should be processed. Choose from "cpu" and "cuda". :param label_index: Index/Table name where
-    labeled questions are stored :param doc_index: Index/Table name where documents that are used for evaluation are
-    stored
+    :param pipeline:
+    :param document_store: DocumentStore containing the evaluation documents
+    :param device: The device on which the tensors should be processed. Choose from "cpu" and "cuda".
+    :param label_index: Index/Table name where labeled questions are stored
+    :param doc_index: Index/Table name where documents that are used for evaluation are stored
     """
 
     # extract all questions for evaluation
@@ -519,10 +520,11 @@ def eval_titleQA_pipeline(
           - "f1": Average overlap between predicted answers and their corresponding correct answers
           - "top_n_accuracy": Proportion of predicted answers that overlap with correct answer
 
-    :param label_origin: the label for the correct answers :param k_retriever: the number of answers to retrieve from
-    the TitleQAPipeline :param pipeline: The titleQAPipeline :param document_store: DocumentStore containing the
-    evaluation documents and the embeddings of the titles :param label_index: Index/Table name where labeled questions
-    are stored
+    :param label_origin: the label for the correct answers 
+    :param k_retriever: the number of answers to retrieve from the TitleQAPipeline 
+    :param pipeline: The titleQAPipeline 
+    :param document_store: DocumentStore containing the evaluation documents and the embeddings of the titles 
+    :param label_index: Index/Table name where labeled questions are stored
     """
 
     # extract all questions for evaluation

--- a/src/evaluation/utils/utils_optimizer.py
+++ b/src/evaluation/utils/utils_optimizer.py
@@ -15,8 +15,9 @@ class tqdm_skopt(object):
 
 def create_dimensions_from_parameters(parameters):
     """
-    This function creates dimensions for the scikit optimize experiment :param parameters: config file :return: list of
-    dimensions for scikit optimize
+    This function creates dimensions for the scikit optimize experiment 
+    :param parameters: config file 
+    :return: list of dimensions for scikit optimize
     """
     dim1 = Integer(
         name="k_retriever",


### PR DESCRIPTION

## Reference to a related issue

## Why is the change needed

To reuse the entire pipeline in a script that performs non-regression tests. Some parameters have to be configurable (ex. experiment_name, elasticsearch address).

## Description of the change

Options that were related to parameter tuning (grid search or the optimization method) in .env or in src/evaluation/config/retriever_reader_eval_squad_config.py (option "experiment_name") were moved to a separate dictionary in the latter config file.

Elasticsearch hostname and port was made configurable through environment variables.

Grid search and bayesian optimization tuning method were given there own functions in src/evaluation/retriever_reader/retriever_reader_eval_squad.py for clarity. Both now return an iterable of  parameters and results for each pipeline run.

Moved the main body of the pipeline in src/evaluation/retriever_reader/retriever_reader_eval_squad.py to its own function tune_pipeline to easily call it from other python files. It also returns an iterable like the previous functions.

Logging to mlflow is done separately from running the pipeline. This allows to filter or select the runs to log in the non-regression tests (to log only the best run).

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
