### PR TITLE
Non regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ data/vosdroits-latest
 output/
 cached_dense_dicts/
 .env
+
+# Configuration files
+non-regression-tests/known_hosts
+non-regression-tests/.env

--- a/non-regression-tests/.env.template
+++ b/non-regression-tests/.env.template
@@ -1,0 +1,26 @@
+# MLFLOW SSH access
+MLFLOW_SSH_USERNAME=username
+MLFLOW_SSH_HOSTNAME=your.mlflow.hostname
+MLFLOW_SSH_PRIVATE_KEY=~/.ssh/id_rsa
+
+# MLFLOW HTTP access
+MLFLOW_TRACKING_USERNAME=http_login
+MLFLOW_TRACKING_PASSWORD=http_passwd
+MLFLOW_TRACKING_SERVER_URI=https://your.mlflow.hostname/mlflow/
+
+ELASTICSEARCH_HOSTNAME=elasticsearch
+ELASTICSEARCH_PORT=9200
+
+TEST_DATASET=../test/samples/squad/tiny.json
+
+# Branch on which to run the tests
+TEST_BRANCH=master
+
+# Install paths
+SRC_DIR=/usr/local/src
+BIN_DIR=/usr/local/bin
+DATA_DIR=/usr/local/share
+LOG_DIR=/var/log
+LOCK_DIR=/var/lock
+STATE_DIR=/var/lib
+SSH_CONFIG_DIR=/root/.ssh

--- a/non-regression-tests/.env.template
+++ b/non-regression-tests/.env.template
@@ -11,7 +11,7 @@ MLFLOW_TRACKING_SERVER_URI=https://your.mlflow.hostname/mlflow/
 ELASTICSEARCH_HOSTNAME=elasticsearch
 ELASTICSEARCH_PORT=9200
 
-TEST_DATASET=../test/samples/squad/tiny.json
+FQUAD_DATASET=../test/samples/squad/tiny.json
 
 # Branch on which to run the tests
 TEST_BRANCH=master

--- a/non-regression-tests/Dockerfile
+++ b/non-regression-tests/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:21.04
+ARG SRC_DIR
+ARG PIAF_ML_SRC=$SRC_DIR/piaf-ml
+RUN apt-get update
+RUN apt-get install --yes git
+RUN git clone https://github.com/etalab-ia/piaf-ml.git $PIAF_ML_SRC
+RUN echo $SRC_DIR $PIAF_ML_SRC
+WORKDIR $PIAF_ML_SRC
+ARG TEST_BRANCH
+RUN git checkout $TEST_BRANCH
+
+# Add timezone to prevent tzdata installation from blocking
+# https://dev.to/setevoy/docker-configure-tzdata-and-timezone-during-build-20bk
+ENV TZ=Europe/Paris
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get install --yes gcc make python3-pip python3-dev
+RUN pip install -r requirements.txt
+
+ARG NON_REG_TESTS_SRC=$SRC_DIR/non-regression-tests
+ARG BIN_DIR
+COPY non-regression-tests $BIN_DIR/
+COPY non-regression-tests.py $NON_REG_TESTS_SRC/
+COPY .env $NON_REG_TESTS_SRC/
+COPY crontab $NON_REG_TESTS_SRC/
+
+RUN apt-get install --yes cron
+RUN crontab $NON_REG_TESTS_SRC/crontab
+ARG LOG_DIR
+RUN mkdir -p $LOG_DIR/non-regression-tests
+
+
+# Configure ssh access to mlflow server
+ARG SSH_CONFIG_DIR
+RUN mkdir -p $SSH_CONFIG_DIR
+ARG MLFLOW_SSH_USERNAME
+ARG MLFLOW_SSH_HOSTNAME
+RUN echo "Host $MLFLOW_SSH_HOSTNAME\n\
+    User $MLFLOW_SSH_USERNAME" > $SSH_CONFIG_DIR/config
+RUN ln -s /run/secrets/.ssh/id_rsa $SSH_CONFIG_DIR/id_rsa
+COPY known_hosts $SSH_CONFIG_DIR/known_hosts
+
+CMD cron -f

--- a/non-regression-tests/Dockerfile
+++ b/non-regression-tests/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:21.04
+# FROM nvidia/cuda:11.4.0-base-ubuntu20.04 
+FROM pytorch/pytorch:1.9.0-cuda11.1-cudnn8-runtime
 ARG SRC_DIR
 ARG PIAF_ML_SRC=$SRC_DIR/piaf-ml
 RUN apt-get update

--- a/non-regression-tests/Dockerfile
+++ b/non-regression-tests/Dockerfile
@@ -22,6 +22,7 @@ ARG NON_REG_TESTS_SRC=$SRC_DIR/non-regression-tests
 ARG BIN_DIR
 COPY non-regression-tests $BIN_DIR/
 COPY non-regression-tests.py $NON_REG_TESTS_SRC/
+COPY config.py $NON_REG_TESTS_SRC/
 COPY .env $NON_REG_TESTS_SRC/
 COPY crontab $NON_REG_TESTS_SRC/
 

--- a/non-regression-tests/README.md
+++ b/non-regression-tests/README.md
@@ -1,0 +1,12 @@
+This folders is for running non-regression-tests in a scheduled manner.
+
+Usage:
+
+1. Copy the folder to the host that will run the tests.
+2. Copy a test dataset locally.
+2. Copy `.env.template` to `.env` and edit it as needed.
+3. Create the file `known_hosts` and fill it with the mlflow server public key
+   (use ssh-keyscan or connect once manually and copy the content of
+   `~/.ssh/known_hosts`)
+4. Run `docker-compose up -d` to start the container that will run the non
+   regression tests everyday at 4am.

--- a/non-regression-tests/config.py
+++ b/non-regression-tests/config.py
@@ -16,14 +16,14 @@ parameter_tuning_options = {
 }
 
 parameters_fquad = {
-    "k_retriever": [1, 3, 5],
-    "k_title_retriever" : [1, 3, 5], # must be present, but only used when retriever_type == title_bm25
+    "k_retriever": [5],
+    "k_title_retriever" : [1], # must be present, but only used when retriever_type == title_bm25
     "k_reader_per_candidate": [20],
-    "k_reader_total": [5, 10],
+    "k_reader_total": [10],
     "reader_model_version": ["053b085d851196110d7a83d8e0f077d0a18470be"],
     "retriever_model_version": ["1a01b38498875d45f69b2a6721bf6fe87425da39"],
     "dpr_model_version": ["v1.0"],
-    "retriever_type": ["title","bm25"], # Can be bm25, sbert, dpr, title or title_bm25
+    "retriever_type": ["bm25"], # Can be bm25, sbert, dpr, title or title_bm25
     "squad_dataset": [
         os.getenv("DATA_DIR") + "/non-regression-tests/fquad_dataset.json"
     ],
@@ -38,18 +38,18 @@ parameters_fquad = {
 # metrics names and keys are predicates on the corresponding metric which must
 # return true if the value is satisfying.
 pass_criteria_fquad = {
-    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.695
+    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.747
 }
 
 parameters_dila = {
-    "k_retriever": [1, 3, 5],
-    "k_title_retriever" : [1, 3, 5], # must be present, but only used when retriever_type == title_bm25
+    "k_retriever": [1],
+    "k_title_retriever" : [1], # must be present, but only used when retriever_type == title_bm25
     "k_reader_per_candidate": [20],
-    "k_reader_total": [5, 10],
+    "k_reader_total": [10],
     "reader_model_version": ["053b085d851196110d7a83d8e0f077d0a18470be"],
     "retriever_model_version": ["1a01b38498875d45f69b2a6721bf6fe87425da39"],
     "dpr_model_version": ["v1.0"],
-    "retriever_type": ["title","bm25"], # Can be bm25, sbert, dpr, title or title_bm25
+    "retriever_type": ["bm25"], # Can be bm25, sbert, dpr, title or title_bm25
     "squad_dataset": [
         os.getenv("SRC_DIR") + "/piaf-ml/clients/dila/knowledge_base/squad.json"],
     "filter_level": [None],
@@ -63,7 +63,7 @@ parameters_dila = {
 # metrics names and keys are predicates on the corresponding metric which must
 # return true if the value is satisfying.
 pass_criteria_dila = {
-    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.355
+    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.427
 }
 
 

--- a/non-regression-tests/config.py
+++ b/non-regression-tests/config.py
@@ -1,0 +1,73 @@
+import os
+
+parameter_tuning_options = {
+    "experiment_name": "non-regression-tests",
+
+    # Tuning method alternatives:
+    # - "optimization": use bayesian optimisation
+    # - "grid_search"
+    "tuning_method": "grid_search",
+
+    # Additionnal options for the grid search method
+    "use_cache": False,
+
+    # Additionnal options for the optimization method
+    "optimization_ncalls": 10,
+}
+
+parameters_fquad = {
+    "k_retriever": [1, 3, 5],
+    "k_title_retriever" : [1, 3, 5], # must be present, but only used when retriever_type == title_bm25
+    "k_reader_per_candidate": [20],
+    "k_reader_total": [5, 10],
+    "reader_model_version": ["053b085d851196110d7a83d8e0f077d0a18470be"],
+    "retriever_model_version": ["1a01b38498875d45f69b2a6721bf6fe87425da39"],
+    "dpr_model_version": ["v1.0"],
+    "retriever_type": ["title","bm25"], # Can be bm25, sbert, dpr, title or title_bm25
+    "squad_dataset": [
+        os.getenv("DATA_DIR") + "/non-regression-tests/fquad_dataset.json"
+    ],
+    "filter_level": [None],
+    "preprocessing": [False],
+    "boosting" : [1], #default to 1
+    "split_by": ["word"],  # Can be "word", "sentence", or "passage"
+    "split_length": [1000],
+}
+
+# A dictionnary specifying the criteria a test result must pass. Keys are
+# metrics names and keys are predicates on the corresponding metric which must
+# return true if the value is satisfying.
+pass_criteria_fquad = {
+    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.695
+}
+
+parameters_dila = {
+    "k_retriever": [1, 3, 5],
+    "k_title_retriever" : [1, 3, 5], # must be present, but only used when retriever_type == title_bm25
+    "k_reader_per_candidate": [20],
+    "k_reader_total": [5, 10],
+    "reader_model_version": ["053b085d851196110d7a83d8e0f077d0a18470be"],
+    "retriever_model_version": ["1a01b38498875d45f69b2a6721bf6fe87425da39"],
+    "dpr_model_version": ["v1.0"],
+    "retriever_type": ["title","bm25"], # Can be bm25, sbert, dpr, title or title_bm25
+    "squad_dataset": [
+        os.getenv("SRC_DIR") + "/piaf-ml/clients/dila/knowledge_base/squad.json"],
+    "filter_level": [None],
+    "preprocessing": [False],
+    "boosting" : [1], #default to 1
+    "split_by": ["word"],  # Can be "word", "sentence", or "passage"
+    "split_length": [1000],
+}
+
+# A dictionnary specifying the criteria a test result must pass. Keys are
+# metrics names and keys are predicates on the corresponding metric which must
+# return true if the value is satisfying.
+pass_criteria_dila = {
+    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.355
+}
+
+
+tests = [
+    (parameters_fquad, parameter_tuning_options, pass_criteria_fquad),
+    (parameters_dila, parameter_tuning_options, pass_criteria_dila),
+]

--- a/non-regression-tests/config.py
+++ b/non-regression-tests/config.py
@@ -38,7 +38,9 @@ parameters_fquad = {
 # metrics names and keys are predicates on the corresponding metric which must
 # return true if the value is satisfying.
 pass_criteria_fquad = {
-    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.747
+    "reader_topk_accuracy_has_answer": 
+        # metric ~= 0.747 +/- 1%
+        lambda metric: abs(metric / 0.747 - 1) < 0.01
 }
 
 parameters_dila = {
@@ -63,7 +65,9 @@ parameters_dila = {
 # metrics names and keys are predicates on the corresponding metric which must
 # return true if the value is satisfying.
 pass_criteria_dila = {
-    "reader_topk_accuracy_has_answer": lambda metric: metric >= 0.427
+    "reader_topk_accuracy_has_answer":
+        # metric ~= 0.427 +/- 1%
+        lambda metric: abs(metric / 0.427 - 1) < 0.01
 }
 
 

--- a/non-regression-tests/crontab
+++ b/non-regression-tests/crontab
@@ -1,0 +1,1 @@
+0 4 * * * set -a; PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin; . /usr/local/src/non-regression-tests/.env; set +a; /usr/local/bin/non-regression-tests > /var/log/non-regression-tests/$(date -Iseconds) 2>&1

--- a/non-regression-tests/docker-compose.yml
+++ b/non-regression-tests/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   non-regression-tests:
     build:
@@ -12,6 +11,7 @@ services:
         - SSH_CONFIG_DIR=${SSH_CONFIG_DIR}
         - MLFLOW_SSH_USERNAME=${MLFLOW_SSH_USERNAME}
         - MLFLOW_SSH_HOSTNAME=${MLFLOW_SSH_HOSTNAME}
+    runtime: nvidia
     depends_on:
       - elasticsearch
     secrets:

--- a/non-regression-tests/docker-compose.yml
+++ b/non-regression-tests/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         target: .ssh/id_rsa
     volumes:
       - $HOME/.cache/huggingface:/root/.cache/huggingface
-      - ${TEST_DATASET}:${DATA_DIR}/non-regression-tests/eval_dataset.json
+      - ${FQUAD_DATASET}:${DATA_DIR}/non-regression-tests/eval_dataset.json
     env_file: .env
     restart: always
   elasticsearch:

--- a/non-regression-tests/docker-compose.yml
+++ b/non-regression-tests/docker-compose.yml
@@ -1,0 +1,33 @@
+version: "3.3"
+services:
+  non-regression-tests:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - SRC_DIR=${SRC_DIR}
+        - BIN_DIR=${BIN_DIR}
+        - LOG_DIR=${LOG_DIR}
+        - TEST_BRANCH=${TEST_BRANCH}
+        - SSH_CONFIG_DIR=${SSH_CONFIG_DIR}
+        - MLFLOW_SSH_USERNAME=${MLFLOW_SSH_USERNAME}
+        - MLFLOW_SSH_HOSTNAME=${MLFLOW_SSH_HOSTNAME}
+    depends_on:
+      - elasticsearch
+    secrets:
+      - source: ssh-private-key
+        target: .ssh/id_rsa
+    volumes:
+      - $HOME/.cache/huggingface:/root/.cache/huggingface
+      - ${TEST_DATASET}:${DATA_DIR}/non-regression-tests/eval_dataset.json
+    env_file: .env
+    restart: always
+  elasticsearch:
+    image: "elasticsearch:7.6.2"
+    environment:
+      - discovery.type=single-node
+    restart: always
+
+secrets:
+  ssh-private-key:
+    file: ${MLFLOW_SSH_PRIVATE_KEY}

--- a/non-regression-tests/docker-compose.yml
+++ b/non-regression-tests/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         target: .ssh/id_rsa
     volumes:
       - $HOME/.cache/huggingface:/root/.cache/huggingface
-      - ${FQUAD_DATASET}:${DATA_DIR}/non-regression-tests/eval_dataset.json
+      - ${FQUAD_DATASET}:${DATA_DIR}/non-regression-tests/fquad_dataset.json
     env_file: .env
     restart: always
   elasticsearch:

--- a/non-regression-tests/non-regression-tests
+++ b/non-regression-tests/non-regression-tests
@@ -16,9 +16,6 @@ fi
 mkdir -p $(dirname $LOCKFILE)
 echo $$ > $LOCKFILE
 
-PIAF_ML_SRC=$SRC_DIR/piaf-ml
-cd $PIAF_ML_SRC
-
 git fetch origin $TEST_BRANCH
 git reset --hard origin/$TEST_BRANCH
 
@@ -36,7 +33,7 @@ echo $CURRENT_COMMIT > $LAST_COMMIT_FILE
 
 pip install -r requirements.txt
 
-export PYTHONPATH=$PIAF_ML_SRC
+export PYTHONPATH=$SRC_DIR/piaf-ml:$SRC_DIR/non-regression-tests
 python3 $SRC_DIR/non-regression-tests/non-regression-tests.py
 
 rm $LOCKFILE

--- a/non-regression-tests/non-regression-tests
+++ b/non-regression-tests/non-regression-tests
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Strict shell: crash if anything goes wrong
+set -euo pipefail
+
+# If already running, exit.
+# If lockfile is present and it contains the PID of a running process, exit
+LOCKFILE=$LOCK_DIR/non-regression-tests/lock
+if [[ -e $LOCKFILE ]] && kill -0 $(cat $LOCKFILE)
+then
+    echo "Another instance of $0 already running with pid $(cat $LOCKFILE). Exiting."
+    exit 1
+fi
+
+# Write current PID to lockfile
+mkdir -p $(dirname $LOCKFILE)
+echo $$ > $LOCKFILE
+
+PIAF_ML_SRC=$SRC_DIR/piaf-ml
+cd $PIAF_ML_SRC
+
+git fetch origin $TEST_BRANCH
+git reset --hard origin/$TEST_BRANCH
+
+# If there is no new commit since last run, don't run.
+CURRENT_COMMIT=$(git log -n1 --format=format:"%H")
+LAST_COMMIT_FILE=$STATE_DIR/non-regression-tests/last-commit-hash
+if [[ -e $LAST_COMMIT_FILE ]] && [[ $(cat $LAST_COMMIT_FILE) = $CURRENT_COMMIT ]]
+then
+    echo "No new commit since last run. Exiting."
+    exit 0
+fi
+
+mkdir -p $(dirname $LAST_COMMIT_FILE)
+echo $CURRENT_COMMIT > $LAST_COMMIT_FILE
+
+pip install -r requirements.txt
+
+export PYTHONPATH=$PIAF_ML_SRC
+python3 $SRC_DIR/non-regression-tests/non-regression-tests.py
+
+rm $LOCKFILE

--- a/non-regression-tests/non-regression-tests.py
+++ b/non-regression-tests/non-regression-tests.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from elasticsearch import Elasticsearch
+import os
+import sys
+import time
+
+from src.evaluation.retriever_reader.retriever_reader_eval_squad import \
+    tune_pipeline
+from src.evaluation.config.retriever_reader_eval_squad_config import \
+    parameters, parameter_tuning_options
+
+test_dataset = os.getenv("DATA_DIR") + "/non-regression-tests/eval_dataset.json"
+elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME")
+elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT"))
+
+parameters["squad_dataset"] = [test_dataset]
+parameter_tuning_options["experiment_name"] = "non-regression-tests"
+
+# Wait for elasticsearch
+timeout = 60 #seconds
+start_wait = time.time()
+
+es = Elasticsearch([f"http://{elasticsearch_hostname}:{elasticsearch_port}/"], verify_certs=True)
+while not es.ping():
+    print(f"Waiting for Elasticsearch to be ready at " \
+        + f"http://{elasticsearch_hostname}:{elasticsearch_port}")
+    sys.stdout.flush()
+    time.sleep(1)
+    if time.time() - start_wait > timeout:
+        print("Timeout waiting for Elasticsearch at " \
+            + "http://{elasticsearch_hostname}:{elasticsearch_port}. " \
+            + "Elasticsearch not found.")
+
+tune_pipeline(
+    parameters,
+    parameter_tuning_options,
+    elasticsearch_hostname = elasticsearch_hostname,
+    elasticsearch_port = elasticsearch_port)

--- a/non-regression-tests/non-regression-tests.py
+++ b/non-regression-tests/non-regression-tests.py
@@ -13,11 +13,11 @@ from src.evaluation.config.retriever_reader_eval_squad_config import \
 from src.evaluation.utils.logging_management import clean_log
 from src.evaluation.utils.mlflow_management import mlflow_log_run
 
-test_dataset = os.getenv("DATA_DIR") + "/non-regression-tests/eval_dataset.json"
+fquad_dataset = os.getenv("DATA_DIR") + "/non-regression-tests/eval_dataset.json"
 elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME")
 elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT"))
 
-parameters["squad_dataset"] = [test_dataset]
+parameters["squad_dataset"] = [fquad_dataset]
 parameter_tuning_options["experiment_name"] = "non-regression-tests"
 
 # Wait for elasticsearch

--- a/non-regression-tests/non-regression-tests.py
+++ b/non-regression-tests/non-regression-tests.py
@@ -10,6 +10,9 @@ from src.evaluation.retriever_reader.retriever_reader_eval_squad import \
 from src.evaluation.config.retriever_reader_eval_squad_config import \
     parameters, parameter_tuning_options
 
+from src.evaluation.utils.logging_management import clean_log
+from src.evaluation.utils.mlflow_management import mlflow_log_run
+
 test_dataset = os.getenv("DATA_DIR") + "/non-regression-tests/eval_dataset.json"
 elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME")
 elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT"))
@@ -37,3 +40,7 @@ tune_pipeline(
     parameter_tuning_options,
     elasticsearch_hostname = elasticsearch_hostname,
     elasticsearch_port = elasticsearch_port)
+
+for (run_id, params, results) in runs:
+    clean_log()
+    mlflow_log_run(params, results, idx=run_id)


### PR DESCRIPTION
## Reference to a related issue
Targetting #64

## Why is the change needed

## Description of the change

The necessary files to run the job were added to non-regression-tests/.

The crontab triggers the tests at 4 am everyday.

The script non-regression-tests/non-regression-tests is the entrypoint. it pulls the last changes from the github repo and triggers the actual tests (in non-regression-tests/non-regression-tests.py) unless there were no new commits since the last tests were run.

The Dockerfile and docker-compose.yml take care of packaging the environment to run the tests.

The file non-regression-tests/README.md describes the deployment process: copy the folder to the host that will run the tests,
create the files non-regression-tests/.env and non-regression-tests/known_hosts and run docker-compose up -d to deploy.

The tests only run if there has been a new commit since the last run.

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
