### PR TITLE
Merge overlapping answers

### DIFF
--- a/deployment/roles/haystack/files/custom_component.py
+++ b/deployment/roles/haystack/files/custom_component.py
@@ -55,3 +55,108 @@ class JoinDocumentsCustom(BaseComponent):
             "labels": inputs[0].get("labels", None),
         }
         return output, "output_1"
+
+
+
+
+class MergeOverlappingAnswers():
+    """
+    A node that merges two answers when they overlap to avoid having multiple
+    answers that are almost identical, like "fichier informatique" and "un petit
+    fichier informatique" as responses to the query "qu'est-ce qu'un cookie ?".
+    The resulting answer contains both answers merged together.
+
+    Two answers can merge only if they come from the same contexts, i.e. if the
+    contexts themselves merge.
+    """
+
+    outgoing_edges=1
+
+    def run(self, **kwargs):
+        answers = kwargs["answers"]
+        merged_answers = []
+
+        for ans in answers:
+            if ans["context"] == None or ans["answer"] == None: continue
+            # Merge ans with the first possible answer in merged_answers
+            is_merged = False
+            i = 0
+            while not is_merged and i < len(merged_answers):
+                mans = merged_answers[i]
+                new_merged_ctxt = merge_strings(mans["context"], ans["context"])
+                if new_merged_ctxt != "":
+                    new_merged_ans = merge_strings(mans["answer"], ans["answer"])
+                    if new_merged_ans != "":
+                        offset_start = new_merged_ctxt.find(new_merged_ans)
+                        merged_answers[i] = {
+                              'answer': new_merged_ans,
+                              'context': new_merged_ctxt,
+                              'document_id': mans["document_id"],
+                              'meta': mans["meta"],
+                              'offset_end': offset_start + len(new_merged_ans),
+                              'offset_start': offset_start,
+                              'probability': max(mans["probability"],
+                                  ans["probability"]),
+                              'score': None}
+                        is_merged = True
+                i += 1
+
+            # If ans wasn't merged with anything, add it as is to merged_answers
+            if not is_merged:
+                merged_answers.append(ans)
+
+        output = kwargs.copy()
+        output["answers"] = merged_answers
+
+        return output, "output_1"
+
+
+
+
+def merge_strings(str1, str2):
+    """
+    Returns (m, s) where m is a string that is the combination of str1 and str2
+    if they overlap and s is the overlap size. If they don't overlap, m an
+    empty string. For example:
+
+    merge_strings("a black", "black coffee") == "a black coffee"
+    merge_strings("a black coffee", "black") == "a black coffee"
+    merge_strings("a black coffee", "") == ""
+    """
+
+    if str1 == "" or str2 == "": return ""
+
+    # Brute force algorithm for a start. Probably inefficient for large 
+    # sequences.
+    # Outline: Start by comparing the end of str1 with the beginning of str2. 
+    # Shift each sequence towards the other one character at a time. Keep the
+    # positions of the longest matching string in both sequences.
+
+    # Best match
+    best_i = len(str1)
+    best_s = 0
+
+    # i is the number of characters by which to shift the beginning of str2 to
+    # the right of the beginning of str1.
+    for i in range(len(str1) - 1, -len(str2), -1):
+
+        if i >= 0:
+            # Current size of compared substrings
+            s = min(len(str1) - i, len(str2))
+            # Positions of compared substrings in str1 and str2
+            start1 = i
+            start2 = 0
+        else: # i < 0
+            s = min(len(str2) + i, len(str1))
+            start1 = 0
+            start2 = -i
+
+        if s > best_s \
+                and str1[start1 : start1 + s] == str2[start2 : start2 + s]:
+            best_i = i
+            best_s = s
+
+    if best_i >= 0:
+        return str1 + str2[best_s:]
+    else:
+        return str2 + str1[best_s:]

--- a/src/evaluation/utils/custom_pipelines.py
+++ b/src/evaluation/utils/custom_pipelines.py
@@ -6,6 +6,9 @@ from haystack.reader.base import BaseReader
 from haystack.retriever.base import BaseRetriever
 from haystack.schema import BaseComponent
 
+from deployment.roles.haystack.files.custom_component import \
+    MergeOverlappingAnswers, JoinDocumentsCustom
+
 
 class TitleQAPipeline(BaseStandardPipeline):
     def __init__(self, retriever: BaseRetriever):
@@ -78,7 +81,7 @@ class TitleBM25QAPipeline(BaseStandardPipeline):
             component=retriever_title, name="Retriever_title", inputs=["Query"]
         )
         self.pipeline.add_node(
-            component=JoinDocuments(ks_retriever=[k_bm25_retriever, k_title_retriever]),
+            component=JoinDocumentsCustom(ks_retriever=[k_bm25_retriever, k_title_retriever]),
             name="JoinResults",
             inputs=["Retriever_bm25", "Retriever_title"],
         )
@@ -180,7 +183,7 @@ class TitleBM25QAEvaluationPipeline(BaseStandardPipeline):
 
         self.pipeline.add_node(component=retriever_bm25, name="Retriever_bm25", inputs=["Query"])
         self.pipeline.add_node(component=retriever_title, name="Retriever_title", inputs=["Query"])
-        self.pipeline.add_node(component=JoinDocuments(ks_retriever=[k_bm25_retriever, k_title_retriever]), name="JoinResults",
+        self.pipeline.add_node(component=JoinDocumentsCustom(ks_retriever=[k_bm25_retriever, k_title_retriever]), name="JoinResults",
                                inputs=["Retriever_bm25", "Retriever_title"])
 
         self.pipeline.add_node(component=eval_retriever, name="EvalRetriever", inputs=["JoinResults"])
@@ -200,150 +203,3 @@ class TitleBM25QAEvaluationPipeline(BaseStandardPipeline):
         )
 
         return output
-
-class JoinDocuments(BaseComponent):
-    """
-    A node to join documents outputted by multiple retriever nodes.
-
-    The node allows multiple join modes:
-
-    * concatenate: combine the documents from multiple nodes. Any duplicate documents are discarded.
-    * merge: merge scores of documents from multiple nodes. Optionally, each input score can be given a different
-      `weight` & a `top_k` limit can be set. This mode can also be used for "reranking" retrieved documents.
-    """
-
-    outgoing_edges = 1
-
-    def __init__(self, ks_retriever: List[int] = None):
-        """
-        :param ks_retriever: A node-wise list(length of list must be equal to the number of input nodes) of k_retriever
-        kept for the concatenation of the retrievers in the nodes. If set to None, the number of documents retrieved
-        will be used
-        """
-        self.ks_retriever = ks_retriever
-
-    def run(self, **kwargs):
-        inputs = kwargs["inputs"]
-
-        document_map = {}
-        if self.ks_retriever:
-            ks_retriever = self.ks_retriever
-        else:
-            ks_retriever = [len(inputs[0]["documents"]) for i in range(len(inputs))]
-        for input_from_node, k_retriever in zip(inputs, ks_retriever):
-            for i, doc in enumerate(input_from_node["documents"]):
-                if i == k_retriever:
-                    break
-                document_map[doc.id] = doc
-        documents = document_map.values()
-        output = {
-            "query": inputs[0]["query"],
-            "documents": documents,
-            "labels": inputs[0].get("labels", None),
-        }
-        return output, "output_1"
-
-
-
-
-class MergeOverlappingAnswers():
-    """
-    A node that merges two answers when they overlap to avoid having multiple
-    answers that are almost identical, like "fichier informatique" and "un petit
-    fichier informatique" as responses to the query "qu'est-ce qu'un cookie ?".
-    The resulting answer contains both answers merged together.
-
-    Two answers can merge only if they come from the same contexts, i.e. if the
-    contexts themselves merge.
-    """
-
-    outgoing_edges=1
-
-    def run(self, **kwargs):
-        answers = kwargs["answers"]
-        merged_answers = []
-
-        for ans in answers:
-            if ans["context"] == None or ans["answer"] == None: continue
-            # Merge ans with the first possible answer in merged_answers
-            is_merged = False
-            i = 0
-            while not is_merged and i < len(merged_answers):
-                mans = merged_answers[i]
-                new_merged_ctxt = merge_strings(mans["context"], ans["context"])
-                if new_merged_ctxt != "":
-                    new_merged_ans = merge_strings(mans["answer"], ans["answer"])
-                    if new_merged_ans != "":
-                        offset_start = new_merged_ctxt.find(new_merged_ans)
-                        merged_answers[i] = {
-                              'answer': new_merged_ans,
-                              'context': new_merged_ctxt,
-                              'document_id': mans["document_id"],
-                              'meta': mans["meta"],
-                              'offset_end': offset_start + len(new_merged_ans),
-                              'offset_start': offset_start,
-                              'probability': max(mans["probability"],
-                                  ans["probability"]),
-                              'score': None}
-                        is_merged = True
-                i += 1
-
-            # If ans wasn't merged with anything, add it as is to merged_answers
-            if not is_merged:
-                merged_answers.append(ans)
-
-        output = kwargs.copy()
-        output["answers"] = merged_answers
-
-        return output, "output_1"
-
-
-
-
-def merge_strings(str1, str2):
-    """
-    Returns (m, s) where m is a string that is the combination of str1 and str2
-    if they overlap and s is the overlap size. If they don't overlap, m an
-    empty string. For example:
-
-    merge_strings("a black", "black coffee") == "a black coffee"
-    merge_strings("a black coffee", "black") == "a black coffee"
-    merge_strings("a black coffee", "") == ""
-    """
-
-    if str1 == "" or str2 == "": return ""
-
-    # Brute force algorithm for a start. Probably inefficient for large 
-    # sequences.
-    # Outline: Start by comparing the end of str1 with the beginning of str2. 
-    # Shift each sequence towards the other one character at a time. Keep the
-    # positions of the longest matching string in both sequences.
-
-    # Best match
-    best_i = len(str1)
-    best_s = 0
-
-    # i is the number of characters by which to shift the beginning of str2 to
-    # the right of the beginning of str1.
-    for i in range(len(str1) - 1, -len(str2), -1):
-
-        if i >= 0:
-            # Current size of compared substrings
-            s = min(len(str1) - i, len(str2))
-            # Positions of compared substrings in str1 and str2
-            start1 = i
-            start2 = 0
-        else: # i < 0
-            s = min(len(str2) + i, len(str1))
-            start1 = 0
-            start2 = -i
-
-        if s > best_s \
-                and str1[start1 : start1 + s] == str2[start2 : start2 + s]:
-            best_i = i
-            best_s = s
-
-    if best_i >= 0:
-        return str1 + str2[best_s:]
-    else:
-        return str2 + str1[best_s:]

--- a/src/evaluation/utils/custom_pipelines.py
+++ b/src/evaluation/utils/custom_pipelines.py
@@ -123,8 +123,8 @@ class RetrieverReaderEvaluationPipeline(BaseStandardPipeline):
         self.pipeline.add_node(component=retriever, name="Retriever", inputs=["Query"])
         self.pipeline.add_node(component=eval_retriever, name="EvalRetriever", inputs=["Retriever"])
         self.pipeline.add_node(component=reader, name="Reader", inputs=["EvalRetriever"])
+        self.pipeline.add_node(component=MergeOverlappingAnswers(), name="MergeOverlappingAnswers", inputs=["Reader"])
         self.pipeline.add_node(component=eval_reader, name="EvalReader", inputs=["Reader"])
-       
 
 
     def run(self, query, top_k_retriever, top_k_reader, labels):
@@ -242,3 +242,108 @@ class JoinDocuments(BaseComponent):
             "labels": inputs[0].get("labels", None),
         }
         return output, "output_1"
+
+
+
+
+class MergeOverlappingAnswers():
+    """
+    A node that merges two answers when they overlap to avoid having multiple
+    answers that are almost identical, like "fichier informatique" and "un petit
+    fichier informatique" as responses to the query "qu'est-ce qu'un cookie ?".
+    The resulting answer contains both answers merged together.
+
+    Two answers can merge only if they come from the same contexts, i.e. if the
+    contexts themselves merge.
+    """
+
+    outgoing_edges=1
+
+    def run(self, **kwargs):
+        answers = kwargs["answers"]
+        merged_answers = []
+
+        for ans in answers:
+            if ans["context"] == None or ans["answer"] == None: continue
+            # Merge ans with the first possible answer in merged_answers
+            is_merged = False
+            i = 0
+            while not is_merged and i < len(merged_answers):
+                mans = merged_answers[i]
+                new_merged_ctxt = merge_strings(mans["context"], ans["context"])
+                if new_merged_ctxt != "":
+                    new_merged_ans = merge_strings(mans["answer"], ans["answer"])
+                    if new_merged_ans != "":
+                        offset_start = new_merged_ctxt.find(new_merged_ans)
+                        merged_answers[i] = {
+                              'answer': new_merged_ans,
+                              'context': new_merged_ctxt,
+                              'document_id': mans["document_id"],
+                              'meta': mans["meta"],
+                              'offset_end': offset_start + len(new_merged_ans),
+                              'offset_start': offset_start,
+                              'probability': max(mans["probability"],
+                                  ans["probability"]),
+                              'score': None}
+                        is_merged = True
+                i += 1
+
+            # If ans wasn't merged with anything, add it as is to merged_answers
+            if not is_merged:
+                merged_answers.append(ans)
+
+        output = kwargs.copy()
+        output["answers"] = merged_answers
+
+        return output, "output_1"
+
+
+
+
+def merge_strings(str1, str2):
+    """
+    Returns (m, s) where m is a string that is the combination of str1 and str2
+    if they overlap and s is the overlap size. If they don't overlap, m an
+    empty string. For example:
+
+    merge_strings("a black", "black coffee") == "a black coffee"
+    merge_strings("a black coffee", "black") == "a black coffee"
+    merge_strings("a black coffee", "") == ""
+    """
+
+    if str1 == "" or str2 == "": return ""
+
+    # Brute force algorithm for a start. Probably inefficient for large 
+    # sequences.
+    # Outline: Start by comparing the end of str1 with the beginning of str2. 
+    # Shift each sequence towards the other one character at a time. Keep the
+    # positions of the longest matching string in both sequences.
+
+    # Best match
+    best_i = len(str1)
+    best_s = 0
+
+    # i is the number of characters by which to shift the beginning of str2 to
+    # the right of the beginning of str1.
+    for i in range(len(str1) - 1, -len(str2), -1):
+
+        if i >= 0:
+            # Current size of compared substrings
+            s = min(len(str1) - i, len(str2))
+            # Positions of compared substrings in str1 and str2
+            start1 = i
+            start2 = 0
+        else: # i < 0
+            s = min(len(str2) + i, len(str1))
+            start1 = 0
+            start2 = -i
+
+        if s > best_s \
+                and str1[start1 : start1 + s] == str2[start2 : start2 + s]:
+            best_i = i
+            best_s = s
+
+    if best_i >= 0:
+        return str1 + str2[best_s:]
+    else:
+        return str2 + str1[best_s:]

--- a/test/samples/squad/duplicate_answers.json
+++ b/test/samples/squad/duplicate_answers.json
@@ -1,0 +1,59 @@
+{
+    "version": "besoindaide_PIAF_V5.json",
+    "data": [
+        {
+            "title": "Un cookie : qu'est-ce que c'est ?",
+            "theme": " Internet",
+            "sous_theme": " Particuliers ",
+            "dossier": "cookie, traceur, tag, internet, site web, bandeau, consentement, information",
+            "id": 1,
+            "paragraphs": [
+                {
+                    "context": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.).\nLe terme de \"cookie\" recouvre par exemple : les cookies HTTP ;\nles cookies \"flash\" ;\nle r\u00e9sultat du calcul d'empreinte dans le cas du \"fingerprinting\" (calcul d'un identifiant unique de la machine bas\u00e9e sur des \u00e9l\u00e9ments de sa configuration \u00e0 des fins de tra\u00e7age) ;\nles pixels invisibles ou \"web bugs\" ;\ntout autre identifiant g\u00e9n\u00e9r\u00e9 par un logiciel ou un syst\u00e8me d'exploitation, par exemple.\nL'utilisation de ces outils est soumise \u00e0 votre consentement d\u00e8s lors qu'ils ne sont pas strictement n\u00e9cessaires au fonctionnement du site concern\u00e9.",
+                    "qas": [
+                        {
+                            "question": "Un cookie : qu'est-ce que c'est ?",
+                            "answers": [
+                                {
+                                    "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        },
+                        {
+                            "question": "Sur Internet, un cookie, c'est quoi ?",
+                            "answers": [
+                                {
+                                    "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
+                                "answer_start": 0
+                            }
+                        ],
+                        "is_impossible": false
+                    },
+                    {
+                        "question": "A quoi \u00e7a sert un cookie ?",
+                        "answers": [
+                            {
+                                "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
+                                "answer_start": 0
+                            }
+                        ],
+                        "is_impossible": false
+                    },
+                    {
+                        "question": "C'est quoi les cookies ?",
+                        "answers": [
+                            {
+                                "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
+                                "answer_start": 0
+                            }
+                        ],
+                        "is_impossible": false
+                    }
+                ]
+            }
+        ]
+    }
+    ]
+}

--- a/test/test_eval_retriever_reader.py
+++ b/test/test_eval_retriever_reader.py
@@ -77,3 +77,5 @@ def test_eval_elastic_retriever_reader(document_store: BaseDocumentStore, retrie
     # clean up
     document_store.delete_all_documents(index=doc_index)
     document_store.delete_all_documents(index=label_index)
+
+

--- a/test/test_no_duplicate_answers.py
+++ b/test/test_no_duplicate_answers.py
@@ -1,0 +1,47 @@
+import pytest
+from pathlib import Path
+from collections import defaultdict
+
+from haystack.document_store.base import BaseDocumentStore
+from haystack.pipeline import Pipeline
+
+from src.evaluation.utils.utils_eval import full_eval_retriever_reader
+from src.evaluation.utils.custom_pipelines import MergeOverlappingAnswers, \
+    merge_strings
+
+def test_merge_strings():
+    assert merge_strings("a black", "black coffee") == "a black coffee"
+    assert merge_strings("black coffee", "a black") == "a black coffee"
+    assert merge_strings("a black coffee", "black") == "a black coffee"
+    assert merge_strings("black", "a black coffee") == "a black coffee"
+    assert merge_strings("a black coffee", "") == ""
+
+
+@pytest.mark.elasticsearch
+def test_no_duplicate_answers(document_store: BaseDocumentStore, retriever_bm25, reader):
+    doc_index = "document"
+    label_index = "label"
+
+    p = Pipeline()
+    p.add_node(component=retriever_bm25, name="Retriever", inputs=["Query"])
+    p.add_node(component=reader, name="Reader", inputs=['Retriever'])
+    p.add_node(component=MergeOverlappingAnswers(), name="MergeOverlappingAnswers", inputs=["Reader"])
+
+    # add eval data (SQUAD format)
+    document_store.delete_all_documents(index=doc_index)
+    document_store.delete_all_documents(index=label_index)
+    document_store.add_eval_data(
+        filename=Path("./test/samples/squad/duplicate_answers.json").as_posix(),
+        doc_index=doc_index,
+        label_index=label_index,
+    )
+
+    res = p.run( query="c'est quoi un cookie ?", top_k_retriever = 3, top_k_reader = 5)
+
+    # There must be only one answer that contains the text "petit fichier informatique"
+    answers = [ans for ans in res["answers"] if ans["answer"] and ans["answer"].find("petit fichier informatique") != -1]
+    assert len(answers) == 1
+
+    # clean up
+    document_store.delete_all_documents(index=doc_index)
+    document_store.delete_all_documents(index=label_index)

--- a/test/test_no_duplicate_answers.py
+++ b/test/test_no_duplicate_answers.py
@@ -6,8 +6,10 @@ from haystack.document_store.base import BaseDocumentStore
 from haystack.pipeline import Pipeline
 
 from src.evaluation.utils.utils_eval import full_eval_retriever_reader
-from src.evaluation.utils.custom_pipelines import MergeOverlappingAnswers, \
-    merge_strings
+from deployment.roles.haystack.files.custom_component import \
+    MergeOverlappingAnswers, merge_strings
+
+
 
 def test_merge_strings():
     assert merge_strings("a black", "black coffee") == "a black coffee"


### PR DESCRIPTION
## Reference to a related issue

Targetting #69

## Why is the change needed

Because the reader sometimes give multiple answers that are almost the same, like "un petit fichier informatique" and "fichier informatique". We would like these two answers to appear only as one.

## Description of the change

This PR introduces a node to add after the Reader node. It merges answers that overlap, i.e. when one answer is included in another or corresponds to the beginning or end of another. It produces a single answer that includes both. For example two answers "un petit fichier" and "fichier informatique" would become the single answer "un petit fichier informatique". 

I added the constraint that in order to merge, two answers must share the same contexts. But I've noticed that two answers may have almost the same context but not exactly equal. Thus, the node will merge answers only if their contexts merge too. The node thus merges both contexts and answers.

The "probability" field of the new answer takes the maximum probability of both merged answers.

The "meta" field of the new answer is the one of one of the two answers, arbitrarily. I wasn't sure how to handle that nor whether or not it is important.

I used somewhat "brute force" algorithms which may not be super efficient with very long data. But since the number of answers out of the pipeline and their length are reasonably small, it might not be a problem.

We still need to add this new node to the pipelines.yaml files, but since there is an issue about generating them automatically which I'm going to take care of next, I'll do it then.

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
