### PR TITLE
Add minimum overlap threshold for contexts and answers.

### DIFF
--- a/clients/cnil/pipelines.yaml
+++ b/clients/cnil/pipelines.yaml
@@ -48,6 +48,8 @@ components:    # define all the building-blocks for Pipeline
     type: PreProcessor
   - name: FileTypeClassifier
     type: FileTypeClassifier
+  - name: MergeOverlappingAnswers
+    type: MergeOverlappingAnswers
 
 pipelines:
   - name: query    # a sample extractive-qa Pipeline
@@ -69,6 +71,8 @@ pipelines:
         inputs: [TitleEmbRetriever,ESRetriever]
       - name: Reader
         inputs: [Join]
+      - name: MergeOverlappingAnswers
+        inputs: [Reader]
 
   - name: indexing
     type: Indexing

--- a/deployment/roles/haystack/files/custom_component.py
+++ b/deployment/roles/haystack/files/custom_component.py
@@ -59,7 +59,7 @@ class JoinDocumentsCustom(BaseComponent):
 
 
 
-class MergeOverlappingAnswers():
+class MergeOverlappingAnswers(BaseComponent):
     """
     A node that merges two answers when they overlap to avoid having multiple
     answers that are almost identical, like "fichier informatique" and "un petit
@@ -72,6 +72,11 @@ class MergeOverlappingAnswers():
 
     outgoing_edges=1
 
+    def __init__(self, minimum_overlap_contexts = 0.75,
+            minimum_overlap_answers = 0.25):
+        self.minimum_overlap_contexts = minimum_overlap_contexts
+        self.minimum_overlap_answers = minimum_overlap_answers
+
     def run(self, **kwargs):
         answers = kwargs["answers"]
         merged_answers = []
@@ -83,9 +88,15 @@ class MergeOverlappingAnswers():
             i = 0
             while not is_merged and i < len(merged_answers):
                 mans = merged_answers[i]
-                new_merged_ctxt = merge_strings(mans["context"], ans["context"])
+                new_merged_ctxt = merge_strings(
+                        mans["context"],
+                        ans["context"],
+                        self.minimum_overlap_contexts)
                 if new_merged_ctxt != "":
-                    new_merged_ans = merge_strings(mans["answer"], ans["answer"])
+                    new_merged_ans = merge_strings(
+                            mans["answer"],
+                            ans["answer"],
+                            self.minimum_overlap_answers)
                     if new_merged_ans != "":
                         offset_start = new_merged_ctxt.find(new_merged_ans)
                         merged_answers[i] = {
@@ -112,29 +123,39 @@ class MergeOverlappingAnswers():
 
 
 
-
-def merge_strings(str1, str2):
+def merge_strings(str1, str2, minimum_overlap):
     """
-    Returns (m, s) where m is a string that is the combination of str1 and str2
-    if they overlap and s is the overlap size. If they don't overlap, m an
-    empty string. For example:
+    Returns a string that is the combination of str1 and str2 if they overlap,
+    otherwise returns an empty string. The two strings are considered to overlap
+    if they are non-empty and one of the following conditions apply:
+    - one is a substring of the other and it's size >= `minimum_overlap * min(len(str1), len(str2))`,
+    - the end of one is equal to the beginning of the other and the size of the
+      common substring is >= `minimum_overlap * min(len(str1), len(str2))`
 
-    merge_strings("a black", "black coffee") == "a black coffee"
-    merge_strings("a black coffee", "black") == "a black coffee"
-    merge_strings("a black coffee", "") == ""
+    For example:
+
+    merge_strings("a black", "black coffee", 0.1) == "a black coffee"
+    merge_strings("a black coffee", "black", 0.1) == "a black coffee"
+    merge_strings("a black coffee", " with milk", 0.1) == ""
+    merge_strings("a black coffee", " with milk", 0) == "a black coffee with milk"
+    merge_strings("a black coffee", "", 0) == ""
+    merge_strings("a coffee is my first thing in the morning", "morning or evening", 0.25) == ""
+    merge_strings("a coffee is my first thing in the morning", "in the morning", 0.25) == "a coffee is my first thing in the morning"
     """
 
     if str1 == "" or str2 == "": return ""
 
-    # Brute force algorithm for a start. Probably inefficient for large 
+    # Brute force algorithm for a start. Probably inefficient for large
     # sequences.
-    # Outline: Start by comparing the end of str1 with the beginning of str2. 
+    # Outline: Start by comparing the end of str1 with the beginning of str2.
     # Shift each sequence towards the other one character at a time. Keep the
     # positions of the longest matching string in both sequences.
 
     # Best match
     best_i = len(str1)
     best_s = 0
+
+    minimum_overlap_chars = int(minimum_overlap * min(len(str1), len(str2)))
 
     # i is the number of characters by which to shift the beginning of str2 to
     # the right of the beginning of str1.
@@ -151,12 +172,16 @@ def merge_strings(str1, str2):
             start1 = 0
             start2 = -i
 
-        if s > best_s \
+        if s >= minimum_overlap_chars \
+                and s > best_s \
                 and str1[start1 : start1 + s] == str2[start2 : start2 + s]:
             best_i = i
             best_s = s
 
-    if best_i >= 0:
-        return str1 + str2[best_s:]
+    if best_s >= minimum_overlap_chars:
+        if best_i >= 0:
+            return str1 + str2[best_s:]
+        else:
+            return str2 + str1[best_s:]
     else:
-        return str2 + str1[best_s:]
+        return ""

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -133,8 +133,6 @@ def retriever_faq(document_store, gpu_available):
         emb_extraction_layer=-1,
     )
 
-
-
 @pytest.fixture
 def Eval_Retriever():
     return PiafEvalRetriever()

--- a/test/samples/squad/duplicate_answers.json
+++ b/test/samples/squad/duplicate_answers.json
@@ -2,6 +2,81 @@
     "version": "besoindaide_PIAF_V5.json",
     "data": [
         {
+            "theme": "Autres",
+            "sous_theme": "Professionnels",
+            "dossier": "",
+            "id": "501",
+            "paragraphs": [
+                {
+                    "context": "Les responsables d'un fichier et les sous-traitants doivent\u00a0prendre toutes les mesures n\u00e9cessaires pour assurer la s\u00e9curit\u00e9 et la confidentialit\u00e9 des donn\u00e9es personnelles qu'ils traitent\u00a0:Des mesures de s\u00e9curit\u00e9 physiques : s\u00e9curit\u00e9 des acc\u00e8s aux locaux ;Des mesures de s\u00e9curit\u00e9 informatiques : antivirus, s\u00e9curisation des mots de passe, etc.Ils doivent\u00a0\u00e9galement veiller \u00e0 ce que seuls les destinataires autoris\u00e9s puissent acc\u00e9der aux donn\u00e9es.En savoir plus :Guide sur la s\u00e9curit\u00e9 des donn\u00e9es personnelles.",
+                    "qas": [
+                        {
+                            "question": "Les mesures de s\u00e9curit\u00e9, c'est quoi ?",
+                            "answers": [
+                                {
+                                    "text": "Les responsables d'un fichier et les sous-traitants doivent\u00a0prendre toutes les mesures n\u00e9cessaires pour assurer la s\u00e9curit\u00e9 et la confidentialit\u00e9 des donn\u00e9es personnelles qu'ils traitent\u00a0:Des mesures de s\u00e9curit\u00e9 physiques : s\u00e9curit\u00e9 des acc\u00e8s aux locaux ;Des mesures de s\u00e9curit\u00e9 informatiques : antivirus, s\u00e9curisation des mots de passe, etc.Ils doivent\u00a0\u00e9galement veiller \u00e0 ce que seuls les destinataires autoris\u00e9s puissent acc\u00e9der aux donn\u00e9es",
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        }
+                    ]
+                }
+            ],
+            "title": "Les mesures de s\u00e9curit\u00e9, c'est quoi ?",
+            "link": "https://www.cnil.fr/cnil-direct/question/les-mesures-de-securite-cest-quoi"
+        },
+        {
+            "theme": "Internet",
+            "sous_theme": "Particuliers",
+            "dossier": "",
+            "id": "375",
+            "paragraphs": [
+                {
+                    "context": "L'hame\u00e7onnage ou phishingest une forme d'escroquerie sur internet.Le fraudeur se fait passer pour un organisme que vous connaissez (banque, service des imp\u00f4ts, CAF, etc.), en utilisant le logo et le nom de cet organisme. Il vous envoie un mail vous demandant g\u00e9n\u00e9ralement de\u00a0\"mettre \u00e0 jour\" ou de \"confirmer vos informations suite \u00e0 un incident technique\", notamment vos coordonn\u00e9es bancaires (num\u00e9ro de compte, codes personnels, etc.).Attention !Ne r\u00e9pondez jamais \u00e0 ces messages, ne cliquez pas sur les liens, n'ouvrez pas les pi\u00e8ces jointes !Que faire ?Signalez les escroqueries aupr\u00e8s du sitewww.internet-signalement.gouv.frSupprimez les messages puis videz la corbeille.S'il s'agit de votre messagerie professionnelle, transf\u00e9rez courriels au service informatique et au responsable de la s\u00e9curit\u00e9 des syst\u00e8mes d'information de votre employeur pour v\u00e9rification. Attendez leur r\u00e9ponse avant de supprimer le courrier \u00e9lectronique.Allez sur la plateformecybermalveillance.gouv.fr: que vous soyez professionnel ou particulier, vous y trouverez des conseils et serez guid\u00e9s pour tenter d'identifier la nature de l'incident dont vous \u00eates victime.Contactez, si vous le souhaitez, Info Escroqueries au 0\u00a0805\u00a0805\u00a0817\u00a0 (prix d'un appel local depuis un poste fixe ; ajouter 0.06 euros/minute depuis un t\u00e9l\u00e9phone mobile) - Du lundi au vendredi de 9h \u00e0 18hEn savoir plus :ici",
+                    "qas": [
+                        {
+                            "question": "Le phishing, c'est quoi ?",
+                            "answers": [
+                                {
+                                    "text": "L'hame\u00e7onnage ou phishingest une forme d'escroquerie sur internet.Le fraudeur se fait passer pour un organisme que vous connaissez (banque, service des imp\u00f4ts, CAF, etc",
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        }
+                    ]
+                }
+            ],
+            "title": "Le phishing, c'est quoi ?",
+            "link": "https://www.cnil.fr/cnil-direct/question/le-phishing-cest-quoi"
+        },
+        {
+            "theme": "Internet",
+            "sous_theme": "Particuliers",
+            "dossier": "",
+            "id": "397",
+            "paragraphs": [
+                {
+                    "context": "G\u00e9n\u00e9ralement, on d\u00e9finit le cloud computing comme le fait d'utiliser des ressources informatiques \u00e0 distance(via internet), par exemple pour sauvegarder des documents, des fichiers, etc. sur des serveurs mis \u00e0 disposition par un prestataire.Le cloud se caract\u00e9rise par la simplicit\u00e9 d'un service \u00e0 la demande,\u00a0le paiement \u00e0 l'usage, un acc\u00e8s l\u00e9ger depuis tout type de terminal et enfin, par lavirtualisationet la mise en commun de ressources qui peuvent \u00eatre r\u00e9parties sur le monde entier.",
+                    "qas": [
+                        {
+                            "question": "Le cloud computing, c'est quoi ?",
+                            "answers": [
+                                {
+                                    "text": "G\u00e9n\u00e9ralement, on d\u00e9finit le cloud computing comme le fait d'utiliser des ressources informatiques \u00e0 distance(via internet), par exemple pour sauvegarder des documents, des fichiers, etc. sur des serveurs mis \u00e0 disposition par un prestataire",
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        }
+                    ]
+                }
+            ],
+            "title": "Le cloud computing, c'est quoi ?",
+            "link": "https://www.cnil.fr/cnil-direct/question/le-cloud-computing-cest-quoi"
+        },
+        {
             "title": "Un cookie : qu'est-ce que c'est ?",
             "theme": " Internet",
             "sous_theme": " Particuliers ",
@@ -26,34 +101,34 @@
                             "answers": [
                                 {
                                     "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
-                                "answer_start": 0
-                            }
-                        ],
-                        "is_impossible": false
-                    },
-                    {
-                        "question": "A quoi \u00e7a sert un cookie ?",
-                        "answers": [
-                            {
-                                "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
-                                "answer_start": 0
-                            }
-                        ],
-                        "is_impossible": false
-                    },
-                    {
-                        "question": "C'est quoi les cookies ?",
-                        "answers": [
-                            {
-                                "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
-                                "answer_start": 0
-                            }
-                        ],
-                        "is_impossible": false
-                    }
-                ]
-            }
-        ]
-    }
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        },
+                        {
+                            "question": "A quoi \u00e7a sert un cookie ?",
+                            "answers": [
+                                {
+                                    "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        },
+                        {
+                            "question": "C'est quoi les cookies ?",
+                            "answers": [
+                                {
+                                    "text": "Un cookie est un petit fichier informatique, un traceur, d\u00e9pos\u00e9 et lu par exemple lors de la consultation d'un site internet, de la lecture d'un courrier \u00e9lectronique, de l'installation ou de l'utilisation d'un logiciel ou d'une application mobile et ce, quel que soit le type de terminal utilis\u00e9 (ordinateur, smartphone, liseuse num\u00e9rique, console de jeux vid\u00e9os connect\u00e9e \u00e0 Internet, etc.)",
+                                    "answer_start": 0
+                                }
+                            ],
+                            "is_impossible": false
+                        }
+                    ]
+                }
+            ]
+        }
     ]
 }

--- a/test/test_no_duplicate_answers.py
+++ b/test/test_no_duplicate_answers.py
@@ -12,11 +12,17 @@ from deployment.roles.haystack.files.custom_component import \
 
 
 def test_merge_strings():
-    assert merge_strings("a black", "black coffee") == "a black coffee"
-    assert merge_strings("black coffee", "a black") == "a black coffee"
-    assert merge_strings("a black coffee", "black") == "a black coffee"
-    assert merge_strings("black", "a black coffee") == "a black coffee"
-    assert merge_strings("a black coffee", "") == ""
+    assert merge_strings("a black", "black coffee", 0.1) == "a black coffee"
+    assert merge_strings("a black coffee", "black", 0.1) == "a black coffee"
+    assert merge_strings("a black coffee", "black", 1) == "a black coffee"
+    assert merge_strings("a black coffee", "a black coffee", 1) == "a black coffee"
+    assert merge_strings("a black coffee", "black coffee,", 1) == ""
+    assert merge_strings("a black coffee", " with milk", 0.1) == ""
+    assert merge_strings("a black coffee", " with milk", 0) == "a black coffee with milk"
+    assert merge_strings("a black coffee", "", 0) == ""
+    assert merge_strings("a black coffee", "", 0.1) == ""
+    assert merge_strings("a coffee is my first thing in the morning", "morning or evening", 0.5) == ""
+    assert merge_strings("a coffee is my first thing in the morning", "in the morning", 0.5) == "a coffee is my first thing in the morning"
 
 
 @pytest.mark.elasticsearch
@@ -27,7 +33,7 @@ def test_no_duplicate_answers(document_store: BaseDocumentStore, retriever_bm25,
     p = Pipeline()
     p.add_node(component=retriever_bm25, name="Retriever", inputs=["Query"])
     p.add_node(component=reader, name="Reader", inputs=['Retriever'])
-    p.add_node(component=MergeOverlappingAnswers(), name="MergeOverlappingAnswers", inputs=["Reader"])
+    p.add_node(component=MergeOverlappingAnswers(0.75, 0.25), name="MergeOverlappingAnswers", inputs=["Reader"])
 
     # add eval data (SQUAD format)
     document_store.delete_all_documents(index=doc_index)


### PR DESCRIPTION
## Reference to a related issue

Fixing issue raised in #129
Alternative proposition to #131

## Why is the change needed

The function `merge_strings` introduced in PR #129 merges any two strings, which results in merging all answers without distinction in the pipeline output.


## Description of the change

Add a minimum thresholfd below which contexts and answers are not merged. As discussed in #131, 2 contexts or answers are merged when they have an exact substring of a minimum length in common in one of the following way: 
- either one string is a substring of the other: "a black coffee" and "black",
- or one ends how the other starts: "a black coffee" and "coffee with milk".
The common substring minimum length is given by the parameter `minimum_overlap` in the function `merge_strings` and is expressed as a fraction of the smallest string length.

That got me thinking that we might need two different minimum overlapping thresholds when merging contexts and answers. Two contexts should perhaps be allowed to merge only when they strongly overlap (ex. minimum_overlap = 0.75) to avoid
merging unrelated contexts. On the other hand, 2 answers within a common context may be allowed to merge with a smaller overlap (ex. minimum_overlap = 0.25) to merge answers that overlap over only a few words. I'm not sure how to set the precise value of these thresholds though, it will probably require trial and error, so I'm making them parameters of the constructor of the class `MergeOverlappingAnswers`.

I also updated the tests and test sample to check that not all answers get merged together.

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
