### PR TITLE
Piaf vs Epitca

### DIFF
--- a/clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json
+++ b/clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json
@@ -1,0 +1,19955 @@
+[
+    {
+        "expected": 61,
+        "epitca": [
+            {
+                "question": "Qu'est ce que le FCC ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "61",
+                            "uri": "/selfcnil/api/configuration/site/document/61"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "75",
+                            "uri": "/selfcnil/api/configuration/site/document/75"
+                        },
+                        "relevance": 95.44078129088123,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "152",
+                            "uri": "/selfcnil/api/configuration/site/document/152"
+                        },
+                        "relevance": 56.91807269412495,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "150",
+                            "uri": "/selfcnil/api/configuration/site/document/150"
+                        },
+                        "relevance": 46.884988007978066,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "156",
+                            "uri": "/selfcnil/api/configuration/site/document/156"
+                        },
+                        "relevance": 33.75867049188467,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "149",
+                            "uri": "/selfcnil/api/configuration/site/document/149"
+                        },
+                        "relevance": 30.606302273142948,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "157",
+                            "uri": "/selfcnil/api/configuration/site/document/157"
+                        },
+                        "relevance": 29.379036658577277,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 28.105039572191203,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "158",
+                            "uri": "/selfcnil/api/configuration/site/document/158"
+                        },
+                        "relevance": 25.509090909090908,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "QU'est-ce qu'on appelle le fichier des ch\u00e8ques ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 95.34482758620689,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "378",
+                            "uri": "/selfcnil/api/configuration/site/document/378"
+                        },
+                        "relevance": 80.35441239560237,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 25.044159438008855,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 24.994493512107876,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 24.96301627949705,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 24.962628245344753,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "219",
+                            "uri": "/selfcnil/api/configuration/site/document/219"
+                        },
+                        "relevance": 24.962174180170738,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 24.962174180170738,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 24.959662555752175,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 24.959068276556742,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "C'est quoi le FCC ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "62",
+                            "uri": "/selfcnil/api/configuration/site/document/62"
+                        },
+                        "relevance": 95.4,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "61",
+                            "uri": "/selfcnil/api/configuration/site/document/61"
+                        },
+                        "relevance": 95.39994941278378,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "152",
+                            "uri": "/selfcnil/api/configuration/site/document/152"
+                        },
+                        "relevance": 87.31028588081044,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "150",
+                            "uri": "/selfcnil/api/configuration/site/document/150"
+                        },
+                        "relevance": 84.63745845644699,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "75",
+                            "uri": "/selfcnil/api/configuration/site/document/75"
+                        },
+                        "relevance": 84.63744496652268,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "160",
+                            "uri": "/selfcnil/api/configuration/site/document/160"
+                        },
+                        "relevance": 80.07600408647936,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "323",
+                            "uri": "/selfcnil/api/configuration/site/document/323"
+                        },
+                        "relevance": 57.809179643089045,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "161",
+                            "uri": "/selfcnil/api/configuration/site/document/161"
+                        },
+                        "relevance": 47.59890939458075,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 39.96610270147895,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 39.93780910414697,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 67,
+        "epitca": [
+            {
+                "question": "Qui a donn\u00e9 mon adresse postale ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 95.7751937984496,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 82.18285393565597,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 82.18261655957306,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 82.18085838062422,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 82.08978144643099,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1308",
+                            "uri": "/selfcnil/api/configuration/site/document/1308"
+                        },
+                        "relevance": 29.7834551238142,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 28.78758901238379,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "762",
+                            "uri": "/selfcnil/api/configuration/site/document/762"
+                        },
+                        "relevance": 28.528213208672714,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "377",
+                            "uri": "/selfcnil/api/configuration/site/document/377"
+                        },
+                        "relevance": 28.425243866016014,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "218",
+                            "uri": "/selfcnil/api/configuration/site/document/218"
+                        },
+                        "relevance": 28.416538704285543,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment a \u00e9t\u00e9 r\u00e9cup\u00e9r\u00e9e l'adresse de mon domicile ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1465",
+                            "uri": "/selfcnil/api/configuration/site/document/1465"
+                        },
+                        "relevance": 95.58823529411765,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 73.15689293154307,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "227",
+                            "uri": "/selfcnil/api/configuration/site/document/227"
+                        },
+                        "relevance": 47.58838233659251,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 47.047586524718646,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 47.04729414462242,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 47.047070249954125,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 47.04703600724016,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "757",
+                            "uri": "/selfcnil/api/configuration/site/document/757"
+                        },
+                        "relevance": 47.0469043044941,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 25.271520070071947,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 25.25875413008253,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Pourquoi est-ce que je re\u00e7ois du courrier publicitaire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 95.32894736842105,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 85.57797178412862,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 85.1087890874477,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 84.25512413560128,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 84.22731675644172,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 84.215430842594,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 84.10637424149502,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 84.09789936609907,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 83.80275527239108,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 83.74853128102937,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 68,
+        "epitca": [
+            {
+                "question": "Qui a donn\u00e9 mon num\u00e9ro de t\u00e9l\u00e9phone ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 95.17857142857143,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "374",
+                            "uri": "/selfcnil/api/configuration/site/document/374"
+                        },
+                        "relevance": 86.48103618279936,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 85.22747398968944,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 82.07827379441727,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "345",
+                            "uri": "/selfcnil/api/configuration/site/document/345"
+                        },
+                        "relevance": 74.15604144600202,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 27.896443908130465,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "68",
+                            "uri": "/selfcnil/api/configuration/site/document/68"
+                        },
+                        "relevance": 27.83609411176328,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "214",
+                            "uri": "/selfcnil/api/configuration/site/document/214"
+                        },
+                        "relevance": 27.6980700165531,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "858",
+                            "uri": "/selfcnil/api/configuration/site/document/858"
+                        },
+                        "relevance": 27.680937538787553,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "179",
+                            "uri": "/selfcnil/api/configuration/site/document/179"
+                        },
+                        "relevance": 27.555168620341107,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment mon num\u00e9ro a-t-il \u00e9t\u00e9 r\u00e9cup\u00e9r\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "419",
+                            "uri": "/selfcnil/api/configuration/site/document/419"
+                        },
+                        "relevance": 95.58823529411765,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 76.74461140851636,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 25.303836673584545,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 25.28466755620473,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 25.284570326328073,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 25.26530397907159,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 25.26530397907159,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 25.25566998146134,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "259",
+                            "uri": "/selfcnil/api/configuration/site/document/259"
+                        },
+                        "relevance": 25.25566998146134,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 25.246035983851094,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Pourquoi mon num\u00e9ro de t\u00e9l\u00e9phone est-il connus de nombreuses soci\u00e9t\u00e9s et comment m'y opposer ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 95.47619047619048,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 84.78071690070962,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "221",
+                            "uri": "/selfcnil/api/configuration/site/document/221"
+                        },
+                        "relevance": 61.165062050354976,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "223",
+                            "uri": "/selfcnil/api/configuration/site/document/223"
+                        },
+                        "relevance": 61.165062050354976,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "68",
+                            "uri": "/selfcnil/api/configuration/site/document/68"
+                        },
+                        "relevance": 59.15664568594345,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 58.955878576638156,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "204",
+                            "uri": "/selfcnil/api/configuration/site/document/204"
+                        },
+                        "relevance": 58.61326576861472,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 58.61218641009563,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 58.61218641009563,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 25.34817364554765,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 84,
+        "epitca": [
+            {
+                "question": "Comment ne plus \u00eatre inscrit au FICP ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "146",
+                            "uri": "/selfcnil/api/configuration/site/document/146"
+                        },
+                        "relevance": 95.66666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "149",
+                            "uri": "/selfcnil/api/configuration/site/document/149"
+                        },
+                        "relevance": 49.26540727113904,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 42.85374708697028,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "147",
+                            "uri": "/selfcnil/api/configuration/site/document/147"
+                        },
+                        "relevance": 37.90298937896775,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "148",
+                            "uri": "/selfcnil/api/configuration/site/document/148"
+                        },
+                        "relevance": 37.82553421328399,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 37.82552177277113,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 37.70914876861685,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 37.709139981511704,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "311",
+                            "uri": "/selfcnil/api/configuration/site/document/311"
+                        },
+                        "relevance": 37.70913851699419,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "161",
+                            "uri": "/selfcnil/api/configuration/site/document/161"
+                        },
+                        "relevance": 33.050757632104116,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Ma dette est effac\u00e9e et je suis toujours enregistr\u00e9 dans le fichier des incidents de remboursement, comment y rem\u00e9dier ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "148",
+                            "uri": "/selfcnil/api/configuration/site/document/148"
+                        },
+                        "relevance": 95.30581039755351,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 89.48767405107601,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 89.38303500105177,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 89.2022982121806,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 89.18289187591199,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 89.18066232906214,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 89.11906301319962,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 89.10458728273441,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "219",
+                            "uri": "/selfcnil/api/configuration/site/document/219"
+                        },
+                        "relevance": 89.01467538876211,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 88.66861803182991,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Je suis \u00e0 tort fich\u00e9 dans le FICP, que peux faire la CNIL ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "84",
+                            "uri": "/selfcnil/api/configuration/site/document/84"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "148",
+                            "uri": "/selfcnil/api/configuration/site/document/148"
+                        },
+                        "relevance": 91.01810008011388,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "149",
+                            "uri": "/selfcnil/api/configuration/site/document/149"
+                        },
+                        "relevance": 40.150017623194465,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "147",
+                            "uri": "/selfcnil/api/configuration/site/document/147"
+                        },
+                        "relevance": 31.97645515016832,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 31.930573556878024,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 31.930573556878024,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "250",
+                            "uri": "/selfcnil/api/configuration/site/document/250"
+                        },
+                        "relevance": 31.861756366186345,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 31.861756366186345,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "228",
+                            "uri": "/selfcnil/api/configuration/site/document/228"
+                        },
+                        "relevance": 31.861751166942557,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 31.86174943386131,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 103,
+        "epitca": [
+            {
+                "question": "Mon employeur me surveille, que faire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 95.25641025641026,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 38.531542386435355,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 38.51198192066385,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 35.60294872721422,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 35.60292595785203,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 35.60292089799377,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 35.602913308206375,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 35.602913308206375,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 35.602913308206375,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 35.602913308206375,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Mon patron ne respecte pas le RGPD, que dois-je faire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 95.14285714285714,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 88.23206584344682,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 50.62868607310899,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 50.3918050459396,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 50.39170824974626,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 50.39170824974626,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 50.391687507704816,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "227",
+                            "uri": "/selfcnil/api/configuration/site/document/227"
+                        },
+                        "relevance": 50.391687507704816,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 50.391687507704816,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 50.391680593691014,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Mon entreprise surveille ses salari\u00e9s, comment y mettre fin ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 95.25641025641026,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "358",
+                            "uri": "/selfcnil/api/configuration/site/document/358"
+                        },
+                        "relevance": 93.48346211246086,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "362",
+                            "uri": "/selfcnil/api/configuration/site/document/362"
+                        },
+                        "relevance": 91.37640874142029,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 80.42824108788152,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 77.0912696332548,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 77.09102985261231,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 77.0910175561691,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "333",
+                            "uri": "/selfcnil/api/configuration/site/document/333"
+                        },
+                        "relevance": 29.126464174255815,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 29.03770075641825,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "343",
+                            "uri": "/selfcnil/api/configuration/site/document/343"
+                        },
+                        "relevance": 29.03714195166324,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 110,
+        "epitca": [
+            {
+                "question": "Je re\u00e7ois trop de courrier postal, comment m'y opposer ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 95.16666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 57.76836612613809,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "180",
+                            "uri": "/selfcnil/api/configuration/site/document/180"
+                        },
+                        "relevance": 32.850568558919385,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "514",
+                            "uri": "/selfcnil/api/configuration/site/document/514"
+                        },
+                        "relevance": 32.8389899675415,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 28.74562548780694,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "368",
+                            "uri": "/selfcnil/api/configuration/site/document/368"
+                        },
+                        "relevance": 24.76666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Je re\u00e7ois de nombreux courrier, comment faire que cela cesse ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 95.47619047619048,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1435",
+                            "uri": "/selfcnil/api/configuration/site/document/1435"
+                        },
+                        "relevance": 95.30998220817392,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1539",
+                            "uri": "/selfcnil/api/configuration/site/document/1539"
+                        },
+                        "relevance": 94.4823484595754,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 85.83077140041479,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 25.07634737047939,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 25.076241558051983,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 25.07623973369979,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 25.076216017121233,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 25.07620507100805,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 25.076203246655854,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment faire stopper le d\u00e9marchage par courrier postal ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 95.33333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 61.65705967751045,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 58.498924299033206,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 58.49824302226394,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 58.49805339365546,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 58.49804944305944,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 28.17708214227871,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "185",
+                            "uri": "/selfcnil/api/configuration/site/document/185"
+                        },
+                        "relevance": 28.126847458516597,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "178",
+                            "uri": "/selfcnil/api/configuration/site/document/178"
+                        },
+                        "relevance": 28.105335075570327,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 28.0938091629968,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 111,
+        "epitca": [
+            {
+                "question": "Quels conseils pour faire cesser la prospection commerciale par courrier ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 95.23201856148492,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 94.12974264157599,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 94.09395056107786,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 94.08170877171777,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 94.06257648201337,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 94.05930379234394,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 94.05118356396063,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 94.05110775408261,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 94.05109924296457,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 94.05109838574651,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment arr\u00eater d'\u00eatre d\u00e9march\u00e9 par voie postale ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 95.11111111111111,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "368",
+                            "uri": "/selfcnil/api/configuration/site/document/368"
+                        },
+                        "relevance": 91.15117169172822,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "369",
+                            "uri": "/selfcnil/api/configuration/site/document/369"
+                        },
+                        "relevance": 72.24707265074788,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 67.85306581863384,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "178",
+                            "uri": "/selfcnil/api/configuration/site/document/178"
+                        },
+                        "relevance": 24.711550401319755,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "514",
+                            "uri": "/selfcnil/api/configuration/site/document/514"
+                        },
+                        "relevance": 24.711231691153568,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1631",
+                            "uri": "/selfcnil/api/configuration/site/document/1631"
+                        },
+                        "relevance": 24.711201880736983,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "111",
+                            "uri": "/selfcnil/api/configuration/site/document/111"
+                        },
+                        "relevance": 24.711179323375536,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 24.711111111111112,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Je re\u00e7ois trop de courrier publicitaire, comme faire que cela cesse ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "111",
+                            "uri": "/selfcnil/api/configuration/site/document/111"
+                        },
+                        "relevance": 95.33333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 48.139862598579505,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 5.333333333333333,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 112,
+        "epitca": [
+            {
+                "question": "Je re\u00e7ois trop d'appels t\u00e9l\u00e9phoniques publicitaire, que faire ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 95.33333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 58.22128970793449,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "858",
+                            "uri": "/selfcnil/api/configuration/site/document/858"
+                        },
+                        "relevance": 5.333333333333333,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment m'opposer au d\u00e9marchage par t\u00e9l\u00e9phone ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 95.1,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 39.38849057004491,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 39.38846973852825,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "106",
+                            "uri": "/selfcnil/api/configuration/site/document/106"
+                        },
+                        "relevance": 39.388443699132424,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 39.3884419631727,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 36.89648972465108,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "68",
+                            "uri": "/selfcnil/api/configuration/site/document/68"
+                        },
+                        "relevance": 24.70962317182874,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "180",
+                            "uri": "/selfcnil/api/configuration/site/document/180"
+                        },
+                        "relevance": 24.705376552364736,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "111",
+                            "uri": "/selfcnil/api/configuration/site/document/111"
+                        },
+                        "relevance": 24.704726604168478,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "514",
+                            "uri": "/selfcnil/api/configuration/site/document/514"
+                        },
+                        "relevance": 24.700000000000003,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment supprimer mon num\u00e9ros de t\u00e9l\u00e9phone des listes de d\u00e9marchage publicitaire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 45.642219730451345,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "185",
+                            "uri": "/selfcnil/api/configuration/site/document/185"
+                        },
+                        "relevance": 39.31822782543687,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 37.91517035248405,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 37.91438044923738,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "430",
+                            "uri": "/selfcnil/api/configuration/site/document/430"
+                        },
+                        "relevance": 37.914342487158976,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "357",
+                            "uri": "/selfcnil/api/configuration/site/document/357"
+                        },
+                        "relevance": 37.914342487158976,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 37.914342487158976,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 32.918048999738566,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "179",
+                            "uri": "/selfcnil/api/configuration/site/document/179"
+                        },
+                        "relevance": 25.509114711039537,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 154,
+        "epitca": [
+            {
+                "question": "Combien de temps mes donn\u00e9es sont-elles dans FICOBA ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "154",
+                            "uri": "/selfcnil/api/configuration/site/document/154"
+                        },
+                        "relevance": 95.25,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 70.06923643453948,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "155",
+                            "uri": "/selfcnil/api/configuration/site/document/155"
+                        },
+                        "relevance": 35.03076356546052,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 5.25,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Combien de temps est-on fich\u00e9 dans FICOBA ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 95.38461538461539,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "149",
+                            "uri": "/selfcnil/api/configuration/site/document/149"
+                        },
+                        "relevance": 42.24405024627028,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "75",
+                            "uri": "/selfcnil/api/configuration/site/document/75"
+                        },
+                        "relevance": 38.28585957881041,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 38.28584974207531,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 38.28584974207531,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "311",
+                            "uri": "/selfcnil/api/configuration/site/document/311"
+                        },
+                        "relevance": 38.285837937993186,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 38.285832035952126,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 38.285832035952126,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 38.28579268901172,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 38.28579268901172,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Le fichage dans FICOBA \u00e7a dure combien de temps ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "154",
+                            "uri": "/selfcnil/api/configuration/site/document/154"
+                        },
+                        "relevance": 95.625,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 53.92261212674616,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "311",
+                            "uri": "/selfcnil/api/configuration/site/document/311"
+                        },
+                        "relevance": 53.92259185891552,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 53.922514165564685,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 53.922514165564685,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "155",
+                            "uri": "/selfcnil/api/configuration/site/document/155"
+                        },
+                        "relevance": 30.281801268415613,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1423",
+                            "uri": "/selfcnil/api/configuration/site/document/1423"
+                        },
+                        "relevance": 29.988469796922463,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 29.967475481056816,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 29.963770413956652,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 29.962871732067857,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 178,
+        "epitca": [
+            {
+                "question": "Je re\u00e7ois toujours \u00e9normement de publicit\u00e9, comment faire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 95.33333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 92.96150780993358,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 92.6168757761919,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "179",
+                            "uri": "/selfcnil/api/configuration/site/document/179"
+                        },
+                        "relevance": 90.68174120556176,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 42.01969465725826,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 42.0196268196104,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 42.0196268196104,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 42.0196206525515,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 42.01958981725702,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 42.01958981725702,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Je re\u00e7ois encore de nombreux courriers publicitaires, pourquoi ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "368",
+                            "uri": "/selfcnil/api/configuration/site/document/368"
+                        },
+                        "relevance": 95.28571428571429,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "369",
+                            "uri": "/selfcnil/api/configuration/site/document/369"
+                        },
+                        "relevance": 84.27682607465526,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 73.86907180379417,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 73.85202004534176,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 73.85044721438972,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 69.93006552030762,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 69.92982163178333,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 28.959666483609553,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 28.959564659870736,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "178",
+                            "uri": "/selfcnil/api/configuration/site/document/178"
+                        },
+                        "relevance": 28.93560249727889,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Je me suis oppos\u00e9 mais re\u00e7ois toujours des courriers de d\u00e9marchage publicitaire, comment faire cesser cela ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "110",
+                            "uri": "/selfcnil/api/configuration/site/document/110"
+                        },
+                        "relevance": 84.2478332048286,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "111",
+                            "uri": "/selfcnil/api/configuration/site/document/111"
+                        },
+                        "relevance": 75.4298488867634,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "182",
+                            "uri": "/selfcnil/api/configuration/site/document/182"
+                        },
+                        "relevance": 60.95529607548398,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 55.34056031149605,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 55.33840013849893,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 55.33818756828379,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 55.338141607156174,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "196",
+                            "uri": "/selfcnil/api/configuration/site/document/196"
+                        },
+                        "relevance": 54.15456210163233,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "178",
+                            "uri": "/selfcnil/api/configuration/site/document/178"
+                        },
+                        "relevance": 44.318139640021364,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 184,
+        "epitca": [
+            {
+                "question": "Je suis spamm\u00e9 de mails publicitaire, comme faire que cela cesse ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 95.46296296296296,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 81.28859847787665,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 81.0985990013404,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 81.05917375033731,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "178",
+                            "uri": "/selfcnil/api/configuration/site/document/178"
+                        },
+                        "relevance": 44.01517273861319,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "368",
+                            "uri": "/selfcnil/api/configuration/site/document/368"
+                        },
+                        "relevance": 36.89251683827095,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "177",
+                            "uri": "/selfcnil/api/configuration/site/document/177"
+                        },
+                        "relevance": 33.32063913126909,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "373",
+                            "uri": "/selfcnil/api/configuration/site/document/373"
+                        },
+                        "relevance": 29.48032854849766,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "343",
+                            "uri": "/selfcnil/api/configuration/site/document/343"
+                        },
+                        "relevance": 28.842311643810277,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "369",
+                            "uri": "/selfcnil/api/configuration/site/document/369"
+                        },
+                        "relevance": 28.661159017193345,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment arr\u00eater de recevoir des emails de pub ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 95.16666666666667,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 52.9649789828967,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 51.523056658505205,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "196",
+                            "uri": "/selfcnil/api/configuration/site/document/196"
+                        },
+                        "relevance": 37.626415737138124,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 5.166666666666667,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Puis-je m'opposer \u00e0 l'envoi de publicit\u00e9s par email ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "372",
+                            "uri": "/selfcnil/api/configuration/site/document/372"
+                        },
+                        "relevance": 95.25,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 70.45146379162409,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 25.520057361081882,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 24.85,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 185,
+        "epitca": [
+            {
+                "question": "Je re\u00e7ois trop de spams par SMS, comment m'y opposer ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 41.21618978634922,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "185",
+                            "uri": "/selfcnil/api/configuration/site/document/185"
+                        },
+                        "relevance": 35.412032999518516,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "68",
+                            "uri": "/selfcnil/api/configuration/site/document/68"
+                        },
+                        "relevance": 35.277022251243174,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "672",
+                            "uri": "/selfcnil/api/configuration/site/document/672"
+                        },
+                        "relevance": 35.22238865382949,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 35.22238865382949,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 24.827667264190328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 24.827667264190328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "239",
+                            "uri": "/selfcnil/api/configuration/site/document/239"
+                        },
+                        "relevance": 24.827667264190328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "242",
+                            "uri": "/selfcnil/api/configuration/site/document/242"
+                        },
+                        "relevance": 24.827667264190328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 24.82648015992399,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Puis je arr\u00eater de recevoir des SMS et MMS de pub ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 95.2,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "373",
+                            "uri": "/selfcnil/api/configuration/site/document/373"
+                        },
+                        "relevance": 73.45403063377411,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "374",
+                            "uri": "/selfcnil/api/configuration/site/document/374"
+                        },
+                        "relevance": 53.81864662251339,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "185",
+                            "uri": "/selfcnil/api/configuration/site/document/185"
+                        },
+                        "relevance": 11.577500515123983,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 5.2,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quels conseils pour lutter contre la publicit\u00e9 par SMS ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 95.2,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "514",
+                            "uri": "/selfcnil/api/configuration/site/document/514"
+                        },
+                        "relevance": 49.08735411355147,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 48.547939863555634,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 48.54398190394193,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "185",
+                            "uri": "/selfcnil/api/configuration/site/document/185"
+                        },
+                        "relevance": 5.2,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 198,
+        "epitca": [
+            {
+                "question": "Sur Internet, un cookie, c'est quoi ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 95.58823529411765,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 94.58179275242053,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "198",
+                            "uri": "/selfcnil/api/configuration/site/document/198"
+                        },
+                        "relevance": 58.859673690398985,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1640",
+                            "uri": "/selfcnil/api/configuration/site/document/1640"
+                        },
+                        "relevance": 44.93744422843937,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "208",
+                            "uri": "/selfcnil/api/configuration/site/document/208"
+                        },
+                        "relevance": 44.11016945865553,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 42.59633812424237,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 41.97366078890068,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 41.32778306392958,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1641",
+                            "uri": "/selfcnil/api/configuration/site/document/1641"
+                        },
+                        "relevance": 40.76427709939788,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1639",
+                            "uri": "/selfcnil/api/configuration/site/document/1639"
+                        },
+                        "relevance": 40.425397985063576,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "A quoi \u00e7a sert un cookie ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 84.76708868595831,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "198",
+                            "uri": "/selfcnil/api/configuration/site/document/198"
+                        },
+                        "relevance": 34.82573336254852,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1640",
+                            "uri": "/selfcnil/api/configuration/site/document/1640"
+                        },
+                        "relevance": 33.402091034764396,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1641",
+                            "uri": "/selfcnil/api/configuration/site/document/1641"
+                        },
+                        "relevance": 32.36723092660512,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1639",
+                            "uri": "/selfcnil/api/configuration/site/document/1639"
+                        },
+                        "relevance": 32.36717519720614,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1643",
+                            "uri": "/selfcnil/api/configuration/site/document/1643"
+                        },
+                        "relevance": 32.3588889321955,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1642",
+                            "uri": "/selfcnil/api/configuration/site/document/1642"
+                        },
+                        "relevance": 29.504928939555835,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1658",
+                            "uri": "/selfcnil/api/configuration/site/document/1658"
+                        },
+                        "relevance": 27.44918809466233,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "557",
+                            "uri": "/selfcnil/api/configuration/site/document/557"
+                        },
+                        "relevance": 25.05495994195036,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "315",
+                            "uri": "/selfcnil/api/configuration/site/document/315"
+                        },
+                        "relevance": 25.05482148922477,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "C'est quoi les cookies ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1640",
+                            "uri": "/selfcnil/api/configuration/site/document/1640"
+                        },
+                        "relevance": 36.77122797654156,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1641",
+                            "uri": "/selfcnil/api/configuration/site/document/1641"
+                        },
+                        "relevance": 35.29990192920956,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1639",
+                            "uri": "/selfcnil/api/configuration/site/document/1639"
+                        },
+                        "relevance": 35.29982038162244,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1643",
+                            "uri": "/selfcnil/api/configuration/site/document/1643"
+                        },
+                        "relevance": 35.28804046199202,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1642",
+                            "uri": "/selfcnil/api/configuration/site/document/1642"
+                        },
+                        "relevance": 31.23038820862798,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "198",
+                            "uri": "/selfcnil/api/configuration/site/document/198"
+                        },
+                        "relevance": 28.376532169567042,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "497",
+                            "uri": "/selfcnil/api/configuration/site/document/497"
+                        },
+                        "relevance": 24.951808733608196,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "331",
+                            "uri": "/selfcnil/api/configuration/site/document/331"
+                        },
+                        "relevance": 24.933391489060146,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "208",
+                            "uri": "/selfcnil/api/configuration/site/document/208"
+                        },
+                        "relevance": 24.90309887713766,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 24.903081270272256,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 214,
+        "epitca": [
+            {
+                "question": "Comment contr\u00f4ler mes donn\u00e9es person sur internet ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "343",
+                            "uri": "/selfcnil/api/configuration/site/document/343"
+                        },
+                        "relevance": 95.14285714285714,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "215",
+                            "uri": "/selfcnil/api/configuration/site/document/215"
+                        },
+                        "relevance": 61.452498842769785,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "306",
+                            "uri": "/selfcnil/api/configuration/site/document/306"
+                        },
+                        "relevance": 61.36471851041341,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 25.280661540703502,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "236",
+                            "uri": "/selfcnil/api/configuration/site/document/236"
+                        },
+                        "relevance": 24.923922556983573,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 24.74824898739007,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 24.742857142857144,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment g\u00e9rer mon image en ligne ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1621",
+                            "uri": "/selfcnil/api/configuration/site/document/1621"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 40.22826542169211,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "844",
+                            "uri": "/selfcnil/api/configuration/site/document/844"
+                        },
+                        "relevance": 27.226749423203557,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "227",
+                            "uri": "/selfcnil/api/configuration/site/document/227"
+                        },
+                        "relevance": 27.226706872254127,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 27.226684745760423,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 27.226654109076833,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 27.226642194810992,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 27.226592835709653,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 27.226584325519767,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "404",
+                            "uri": "/selfcnil/api/configuration/site/document/404"
+                        },
+                        "relevance": 25.5834148906358,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quels conseils suivre pour s\u00e9curiser mes donn\u00e9es personnelles sur Internet ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "215",
+                            "uri": "/selfcnil/api/configuration/site/document/215"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "214",
+                            "uri": "/selfcnil/api/configuration/site/document/214"
+                        },
+                        "relevance": 87.18662574548799,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 84.06911739991371,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1308",
+                            "uri": "/selfcnil/api/configuration/site/document/1308"
+                        },
+                        "relevance": 39.64764913637887,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "236",
+                            "uri": "/selfcnil/api/configuration/site/document/236"
+                        },
+                        "relevance": 39.33233958531332,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 25.314395832159953,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 25.314379147633552,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 25.314342441675468,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 25.314335767864915,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 25.31428905119099,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 223,
+        "epitca": [
+            {
+                "question": "O\u00f9 en est ma demande d'acc\u00e8s au Fichier des Comptes Bancaires ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "518",
+                            "uri": "/selfcnil/api/configuration/site/document/518"
+                        },
+                        "relevance": 95.17543859649123,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 87.90568997004797,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "223",
+                            "uri": "/selfcnil/api/configuration/site/document/223"
+                        },
+                        "relevance": 86.24057125044732,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "757",
+                            "uri": "/selfcnil/api/configuration/site/document/757"
+                        },
+                        "relevance": 40.04320210314982,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 39.98253587380385,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 39.92433950045527,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 35.67566429024411,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 35.65498556439459,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 35.65498556439459,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 35.65498556439459,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Puis -je avoir des informations sur l'\u00e9tat d'avancement de ma demande d'acc\u00e8s \u00e0 FICOBA ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 95.21929824561404,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 95.21703662123922,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 94.94734678292002,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 93.3604490478878,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 92.41471603605333,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 92.37175596607388,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "242",
+                            "uri": "/selfcnil/api/configuration/site/document/242"
+                        },
+                        "relevance": 92.25623847163065,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 92.11226606212755,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "221",
+                            "uri": "/selfcnil/api/configuration/site/document/221"
+                        },
+                        "relevance": 92.07631632926864,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 92.07625358941054,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment savoir o\u00f9 en est ma demande d'acc\u00e8s \u00e0 FICOBA ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 95.27027027027027,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "153",
+                            "uri": "/selfcnil/api/configuration/site/document/153"
+                        },
+                        "relevance": 85.74624272178013,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "518",
+                            "uri": "/selfcnil/api/configuration/site/document/518"
+                        },
+                        "relevance": 83.10024179435425,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 83.01038986375865,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 25.142696137555497,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "223",
+                            "uri": "/selfcnil/api/configuration/site/document/223"
+                        },
+                        "relevance": 25.097286098141435,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "155",
+                            "uri": "/selfcnil/api/configuration/site/document/155"
+                        },
+                        "relevance": 24.951970550237135,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "190",
+                            "uri": "/selfcnil/api/configuration/site/document/190"
+                        },
+                        "relevance": 24.8787358430984,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "344",
+                            "uri": "/selfcnil/api/configuration/site/document/344"
+                        },
+                        "relevance": 24.87854537414453,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "434",
+                            "uri": "/selfcnil/api/configuration/site/document/434"
+                        },
+                        "relevance": 24.878302821470363,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 227,
+        "epitca": [
+            {
+                "question": "Est-il possible d'avoir une copie de ma d\u00e9claration \u00e0 la CNIL ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 95.76923076923077,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 43.46702159379098,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 43.21858286301857,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 42.94098047229321,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 42.530798366283186,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 42.24883388966742,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "227",
+                            "uri": "/selfcnil/api/configuration/site/document/227"
+                        },
+                        "relevance": 41.23626975293029,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "672",
+                            "uri": "/selfcnil/api/configuration/site/document/672"
+                        },
+                        "relevance": 32.96164975587456,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 32.96164975587456,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 31.852426170176308,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment avoir un copie de ma d\u00e9claration ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 95.66666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "227",
+                            "uri": "/selfcnil/api/configuration/site/document/227"
+                        },
+                        "relevance": 89.34282959987655,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "672",
+                            "uri": "/selfcnil/api/configuration/site/document/672"
+                        },
+                        "relevance": 29.12767120062556,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 29.12767120062556,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "234",
+                            "uri": "/selfcnil/api/configuration/site/document/234"
+                        },
+                        "relevance": 28.49568312685122,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "773",
+                            "uri": "/selfcnil/api/configuration/site/document/773"
+                        },
+                        "relevance": 28.399826114137227,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 28.3402574253736,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 28.339244040889977,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 28.32376810077201,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 28.263826603447388,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Je ne retrouve pas les d\u00e9clarations que j'ai faites aupr\u00e8s de la CNIL, que faire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "337",
+                            "uri": "/selfcnil/api/configuration/site/document/337"
+                        },
+                        "relevance": 38.22153854207882,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 37.83585273106731,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 37.52103676192266,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "236",
+                            "uri": "/selfcnil/api/configuration/site/document/236"
+                        },
+                        "relevance": 37.206220792778005,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 36.732835863978664,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 35.33023568376623,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "771",
+                            "uri": "/selfcnil/api/configuration/site/document/771"
+                        },
+                        "relevance": 32.33134509329601,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "587",
+                            "uri": "/selfcnil/api/configuration/site/document/587"
+                        },
+                        "relevance": 32.32997407484446,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 31.869175814542462,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 31.684664815642343,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 229,
+        "epitca": [
+            {
+                "question": "C'est quoi le STIC et le JUDEX ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "234",
+                            "uri": "/selfcnil/api/configuration/site/document/234"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "229",
+                            "uri": "/selfcnil/api/configuration/site/document/229"
+                        },
+                        "relevance": 42.633397501567984,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "400",
+                            "uri": "/selfcnil/api/configuration/site/document/400"
+                        },
+                        "relevance": 36.93393321681389,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "232",
+                            "uri": "/selfcnil/api/configuration/site/document/232"
+                        },
+                        "relevance": 35.488548223425255,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "233",
+                            "uri": "/selfcnil/api/configuration/site/document/233"
+                        },
+                        "relevance": 35.488548223425255,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "235",
+                            "uri": "/selfcnil/api/configuration/site/document/235"
+                        },
+                        "relevance": 35.488548223425255,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 34.04316480166531,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1328",
+                            "uri": "/selfcnil/api/configuration/site/document/1328"
+                        },
+                        "relevance": 25.509090909090908,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Qu'est ce que le TAJ ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "234",
+                            "uri": "/selfcnil/api/configuration/site/document/234"
+                        },
+                        "relevance": 95.625,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "235",
+                            "uri": "/selfcnil/api/configuration/site/document/235"
+                        },
+                        "relevance": 92.12140211886776,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "229",
+                            "uri": "/selfcnil/api/configuration/site/document/229"
+                        },
+                        "relevance": 87.86088986973479,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "400",
+                            "uri": "/selfcnil/api/configuration/site/document/400"
+                        },
+                        "relevance": 73.84086644880482,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1328",
+                            "uri": "/selfcnil/api/configuration/site/document/1328"
+                        },
+                        "relevance": 73.70172993145404,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "233",
+                            "uri": "/selfcnil/api/configuration/site/document/233"
+                        },
+                        "relevance": 66.89381747172615,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "232",
+                            "uri": "/selfcnil/api/configuration/site/document/232"
+                        },
+                        "relevance": 66.6861677051651,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 59.532134301231274,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "261",
+                            "uri": "/selfcnil/api/configuration/site/document/261"
+                        },
+                        "relevance": 31.789418200998735,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "260",
+                            "uri": "/selfcnil/api/configuration/site/document/260"
+                        },
+                        "relevance": 30.739104067906066,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Le traitement des ant\u00e9c\u00e9dents judiciaires, c'est quoi ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 55.98271293530358,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1312",
+                            "uri": "/selfcnil/api/configuration/site/document/1312"
+                        },
+                        "relevance": 55.982236214352774,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "235",
+                            "uri": "/selfcnil/api/configuration/site/document/235"
+                        },
+                        "relevance": 36.544452331148925,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "229",
+                            "uri": "/selfcnil/api/configuration/site/document/229"
+                        },
+                        "relevance": 33.23082534524745,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 267,
+        "epitca": [
+            {
+                "question": "Dois-je pr\u00e9senter ma CNI pour payer par ch\u00e8que ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "160",
+                            "uri": "/selfcnil/api/configuration/site/document/160"
+                        },
+                        "relevance": 95.16666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "219",
+                            "uri": "/selfcnil/api/configuration/site/document/219"
+                        },
+                        "relevance": 57.29386878289111,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "323",
+                            "uri": "/selfcnil/api/configuration/site/document/323"
+                        },
+                        "relevance": 52.38872789557137,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "152",
+                            "uri": "/selfcnil/api/configuration/site/document/152"
+                        },
+                        "relevance": 5.166666666666667,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Un commer\u00e7ant me demande de pr\u00e9senter ma CNI pour valider mon paiement par ch\u00e8que, c'est normal ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 95.23980815347721,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 95.2298743300511,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "160",
+                            "uri": "/selfcnil/api/configuration/site/document/160"
+                        },
+                        "relevance": 95.21249543428284,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 95.2117370340308,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 95.21136142226527,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "239",
+                            "uri": "/selfcnil/api/configuration/site/document/239"
+                        },
+                        "relevance": 95.21095582657456,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 95.20998923294236,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "219",
+                            "uri": "/selfcnil/api/configuration/site/document/219"
+                        },
+                        "relevance": 95.20997358523233,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 95.2099608737836,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 95.20992978829969,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Pourquoi montrer une pi\u00e8ce d'identit\u00e9 lors d'un paiement par ch\u00e8que ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "267",
+                            "uri": "/selfcnil/api/configuration/site/document/267"
+                        },
+                        "relevance": 95.19342359767892,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 88.698142424822,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 88.04098613472364,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "204",
+                            "uri": "/selfcnil/api/configuration/site/document/204"
+                        },
+                        "relevance": 87.63842656818936,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 87.51869188652354,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 87.18896703182222,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 87.03303027501616,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "242",
+                            "uri": "/selfcnil/api/configuration/site/document/242"
+                        },
+                        "relevance": 87.01914648159699,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 86.96143928223928,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 86.95831499585903,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 277,
+        "epitca": [
+            {
+                "question": "La mairie peut-elle demander la liste des adh\u00e9rents d'une association ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 95.47619047619048,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "176",
+                            "uri": "/selfcnil/api/configuration/site/document/176"
+                        },
+                        "relevance": 94.21701661758863,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 25.09231603998107,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 25.091538929344114,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 25.090300733062566,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 25.088284389996545,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 25.08715395305665,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 25.08626908307804,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 25.07621223528831,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "242",
+                            "uri": "/selfcnil/api/configuration/site/document/242"
+                        },
+                        "relevance": 25.076206018403212,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Peut-on exiger la communication des informations sur les membres d'une association ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 54.1213049702731,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 51.840988913376194,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "291",
+                            "uri": "/selfcnil/api/configuration/site/document/291"
+                        },
+                        "relevance": 50.81262851062694,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "528",
+                            "uri": "/selfcnil/api/configuration/site/document/528"
+                        },
+                        "relevance": 49.9814574961685,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "858",
+                            "uri": "/selfcnil/api/configuration/site/document/858"
+                        },
+                        "relevance": 26.283833537745675,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 26.133822229857934,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 25.948213199822817,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1397",
+                            "uri": "/selfcnil/api/configuration/site/document/1397"
+                        },
+                        "relevance": 25.838391099510684,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1349",
+                            "uri": "/selfcnil/api/configuration/site/document/1349"
+                        },
+                        "relevance": 25.509090909090908,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Est-il possible pour une collectivit\u00e9 de demander la liste des personnes adh\u00e9rentes d'une association ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 95.1923076923077,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 84.81849708756145,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 84.80525524668023,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "757",
+                            "uri": "/selfcnil/api/configuration/site/document/757"
+                        },
+                        "relevance": 84.32037843169114,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 84.2776313623195,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 84.2746436121037,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 84.27050343118079,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 84.27001992137691,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 84.26992226152016,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 84.26898906633386,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 278,
+        "epitca": [
+            {
+                "question": "Comment g\u00e9rer le droit \u00e0 l'image de mon enfant \u00e0 l'\u00e9cole ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 95.52631578947368,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "287",
+                            "uri": "/selfcnil/api/configuration/site/document/287"
+                        },
+                        "relevance": 87.0699653831022,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 78.18686636356914,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 25.126353259442162,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 25.126343891950043,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 25.12633452445792,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 25.12633452445792,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 25.126323818752645,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 25.126319804113166,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 25.126317127686843,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Est-ce que je peux interdire l'utilisation de photographie de mon fils/ma fille par l'\u00e9cole/la cr\u00e8che ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 95.30959752321982,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 92.20690390127331,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "436",
+                            "uri": "/selfcnil/api/configuration/site/document/436"
+                        },
+                        "relevance": 92.19884206230267,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 92.19431494952127,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 92.19369807411391,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 91.82520052264343,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 91.82519912934384,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 91.36369828181759,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 91.3636894470242,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "259",
+                            "uri": "/selfcnil/api/configuration/site/document/259"
+                        },
+                        "relevance": 90.99737458251545,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment l'\u00e9cole peut-elle utiliser des photos de mon enfant ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 95.3076923076923,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 93.94852550181173,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 93.89019516974756,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 93.56133113449569,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 93.48451655123382,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "583",
+                            "uri": "/selfcnil/api/configuration/site/document/583"
+                        },
+                        "relevance": 93.48164866281373,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 93.1703204327415,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 92.5061290530626,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 92.50609037753286,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 92.50608057759891,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 285,
+        "epitca": [
+            {
+                "question": "Une mairie peut-elle avoir acc\u00e8s au num\u00e9ro de s\u00e9cu d'un enfant ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 95.11111111111111,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "468",
+                            "uri": "/selfcnil/api/configuration/site/document/468"
+                        },
+                        "relevance": 82.1949620272973,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "285",
+                            "uri": "/selfcnil/api/configuration/site/document/285"
+                        },
+                        "relevance": 54.76104230413925,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 32.22431258619779,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "278",
+                            "uri": "/selfcnil/api/configuration/site/document/278"
+                        },
+                        "relevance": 32.21476707942193,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1314",
+                            "uri": "/selfcnil/api/configuration/site/document/1314"
+                        },
+                        "relevance": 32.20055787870473,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 32.19048628387061,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "549",
+                            "uri": "/selfcnil/api/configuration/site/document/549"
+                        },
+                        "relevance": 24.711111111111112,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Quelles sont les r\u00e8gles pour l'acc\u00e8s par une mairie au num\u00e9ro de s\u00e9curit\u00e9 sociale lors de l'inscription \u00e0 l'\u00e9cole ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 95.26178010471205,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 95.25564946587959,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 95.25326084082437,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 95.0870766514457,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 94.8062187823616,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 94.69642234006795,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "688",
+                            "uri": "/selfcnil/api/configuration/site/document/688"
+                        },
+                        "relevance": 94.6783096342139,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 94.64465473204115,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 94.39348854417626,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 94.3683025838439,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Un maire peut-il demander le num\u00e9ro de s\u00e9cu d'un enfant pour son inscription scolaire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 95.21834061135371,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "285",
+                            "uri": "/selfcnil/api/configuration/site/document/285"
+                        },
+                        "relevance": 94.7467562296591,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "468",
+                            "uri": "/selfcnil/api/configuration/site/document/468"
+                        },
+                        "relevance": 93.55991892659569,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "159",
+                            "uri": "/selfcnil/api/configuration/site/document/159"
+                        },
+                        "relevance": 91.96057610385782,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 91.63486610850732,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 90.92439155359533,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 90.88555033423701,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 90.71914482078941,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 90.63277916708456,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 90.2688181836486,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 308,
+        "epitca": [
+            {
+                "question": "Que contient le fichier advance passenger informations passenger name record ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 95.23696682464455,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 94.10070736425814,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 94.07421990434662,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 93.94343428104634,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "219",
+                            "uri": "/selfcnil/api/configuration/site/document/219"
+                        },
+                        "relevance": 93.89986774362566,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 93.87584050108138,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 93.85524305539909,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 93.62604639696303,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 93.5817578827828,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 93.53910634397418,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Qu'y a-t-il dans le fichier PNR ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "306",
+                            "uri": "/selfcnil/api/configuration/site/document/306"
+                        },
+                        "relevance": 95.60240963855422,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 50.610405482991396,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 50.27519108881025,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 50.274876261211155,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 50.263346638773456,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 50.255844780208115,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 50.25575024602351,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 50.238709621514474,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 50.21605174674873,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 49.35959653894394,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quelles informations sont pr\u00e9sentes dans le fichier API ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 95.13888888888889,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 95.13848992449157,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "305",
+                            "uri": "/selfcnil/api/configuration/site/document/305"
+                        },
+                        "relevance": 89.6479676843666,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "308",
+                            "uri": "/selfcnil/api/configuration/site/document/308"
+                        },
+                        "relevance": 89.6479539452744,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "306",
+                            "uri": "/selfcnil/api/configuration/site/document/306"
+                        },
+                        "relevance": 86.51040382753476,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "307",
+                            "uri": "/selfcnil/api/configuration/site/document/307"
+                        },
+                        "relevance": 86.51040039276171,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 24.738901287501413,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 24.738901287501413,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 24.738899182076647,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "293",
+                            "uri": "/selfcnil/api/configuration/site/document/293"
+                        },
+                        "relevance": 24.738899182076647,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 342,
+        "epitca": [
+            {
+                "question": "Comment cloturer le compte mail d'un employ\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "342",
+                            "uri": "/selfcnil/api/configuration/site/document/342"
+                        },
+                        "relevance": 95.38461538461539,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 43.97182789192833,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 38.13438665400943,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "757",
+                            "uri": "/selfcnil/api/configuration/site/document/757"
+                        },
+                        "relevance": 38.1331467248488,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "665",
+                            "uri": "/selfcnil/api/configuration/site/document/665"
+                        },
+                        "relevance": 38.13308636744016,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 38.13302601003151,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "861",
+                            "uri": "/selfcnil/api/configuration/site/document/861"
+                        },
+                        "relevance": 38.132928509602166,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "864",
+                            "uri": "/selfcnil/api/configuration/site/document/864"
+                        },
+                        "relevance": 38.132928509602166,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "183",
+                            "uri": "/selfcnil/api/configuration/site/document/183"
+                        },
+                        "relevance": 38.13291922384699,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "194",
+                            "uri": "/selfcnil/api/configuration/site/document/194"
+                        },
+                        "relevance": 38.13291922384699,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quels conseils pour fermer la bo\u00eete mail d'un salari\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "342",
+                            "uri": "/selfcnil/api/configuration/site/document/342"
+                        },
+                        "relevance": 95.625,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 41.66541585053889,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "366",
+                            "uri": "/selfcnil/api/configuration/site/document/366"
+                        },
+                        "relevance": 41.66538353573745,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 41.665333820658304,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 41.66532139188851,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 41.66530150585686,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 41.66529902010289,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1308",
+                            "uri": "/selfcnil/api/configuration/site/document/1308"
+                        },
+                        "relevance": 25.25351795796326,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 25.253484085866422,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "105",
+                            "uri": "/selfcnil/api/configuration/site/document/105"
+                        },
+                        "relevance": 25.24257022797263,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment faire pour d\u00e9sactiver la messagerie \u00e9lectronique d'un employ\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 95.34843205574913,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 94.41980355629926,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 94.33865854547021,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "366",
+                            "uri": "/selfcnil/api/configuration/site/document/366"
+                        },
+                        "relevance": 94.09333515771598,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "688",
+                            "uri": "/selfcnil/api/configuration/site/document/688"
+                        },
+                        "relevance": 94.0929334168393,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 94.08692566243882,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 84.39973139766548,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "339",
+                            "uri": "/selfcnil/api/configuration/site/document/339"
+                        },
+                        "relevance": 84.1523942135383,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "170",
+                            "uri": "/selfcnil/api/configuration/site/document/170"
+                        },
+                        "relevance": 71.93672053197528,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "342",
+                            "uri": "/selfcnil/api/configuration/site/document/342"
+                        },
+                        "relevance": 64.51620203844813,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 344,
+        "epitca": [
+            {
+                "question": "Mon patron a-t-il le droit de surveiller mon usage du t\u00e9l\u00e9phone pro ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 95.28169014084507,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 89.95740762755084,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 89.36195513778418,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 88.78179092115772,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 88.72954556237039,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 88.62546878761849,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 88.62522318322057,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 88.62470616122697,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 88.34757663447999,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 88.341297274904,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Ma soci\u00e9t\u00e9 peut-elle contr\u00f4ler comment j'utilise mon t\u00e9l\u00e9phone pro ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "68",
+                            "uri": "/selfcnil/api/configuration/site/document/68"
+                        },
+                        "relevance": 95.3030303030303,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "229",
+                            "uri": "/selfcnil/api/configuration/site/document/229"
+                        },
+                        "relevance": 80.6004645859003,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 44.56455404061276,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 44.56447705544257,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 44.56443244972108,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 44.55538903486935,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 44.55534736868987,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 44.55534736868987,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 44.55534736868987,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "688",
+                            "uri": "/selfcnil/api/configuration/site/document/688"
+                        },
+                        "relevance": 44.55534736868987,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Mon employeur m'a fourni un t\u00e9l\u00e9phone professionnel. Peut-il me contr\u00f4ler ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "344",
+                            "uri": "/selfcnil/api/configuration/site/document/344"
+                        },
+                        "relevance": 95.1,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 44.045206784883256,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "236",
+                            "uri": "/selfcnil/api/configuration/site/document/236"
+                        },
+                        "relevance": 28.395521582311535,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 24.71972513712727,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 24.716679989782538,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 24.700039040350575,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "688",
+                            "uri": "/selfcnil/api/configuration/site/document/688"
+                        },
+                        "relevance": 24.7000374136693,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 24.70002277353784,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 24.700009760087646,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 24.700000000000003,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 379,
+        "epitca": [
+            {
+                "question": "Tout le monde peut-il utiliser le registre du commerce ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 95.16666666666667,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "379",
+                            "uri": "/selfcnil/api/configuration/site/document/379"
+                        },
+                        "relevance": 47.399571447773496,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 45.367376347774666,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 40.824630981800304,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "371",
+                            "uri": "/selfcnil/api/configuration/site/document/371"
+                        },
+                        "relevance": 39.58956136100379,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "531",
+                            "uri": "/selfcnil/api/configuration/site/document/531"
+                        },
+                        "relevance": 24.76666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Qui a le droit d'utiliser le registre du commerce et des soci\u00e9t\u00e9s ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 95.26041666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 95.05463687087378,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 94.78837573479179,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 94.75285759056442,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 94.74448660783744,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 94.43112062672895,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 94.43111346382788,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 94.0014184776931,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 94.00137970933692,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 93.68959933501722,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "N'importe qui peut-il utiliser le registre du commerce et des soci\u00e9t\u00e9s ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "379",
+                            "uri": "/selfcnil/api/configuration/site/document/379"
+                        },
+                        "relevance": 95.20661157024793,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 93.64876680162526,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 82.76508775038288,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1312",
+                            "uri": "/selfcnil/api/configuration/site/document/1312"
+                        },
+                        "relevance": 82.76441529661096,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 82.72285145818613,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 82.71220396728746,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 82.71049940145818,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 82.66112088594856,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 82.66063614721688,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 82.64861369591554,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 384,
+        "epitca": [
+            {
+                "question": "Comment marche Google ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "211",
+                            "uri": "/selfcnil/api/configuration/site/document/211"
+                        },
+                        "relevance": 95.29411764705883,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 92.07866061934102,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 92.03475839332965,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 89.21289863666682,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1631",
+                            "uri": "/selfcnil/api/configuration/site/document/1631"
+                        },
+                        "relevance": 84.74552760337549,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "354",
+                            "uri": "/selfcnil/api/configuration/site/document/354"
+                        },
+                        "relevance": 33.55808853705762,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "384",
+                            "uri": "/selfcnil/api/configuration/site/document/384"
+                        },
+                        "relevance": 32.02675577479374,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "209",
+                            "uri": "/selfcnil/api/configuration/site/document/209"
+                        },
+                        "relevance": 30.76807990089202,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "207",
+                            "uri": "/selfcnil/api/configuration/site/document/207"
+                        },
+                        "relevance": 28.455115116456348,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1659",
+                            "uri": "/selfcnil/api/configuration/site/document/1659"
+                        },
+                        "relevance": 28.241592677779355,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment marche un moteur de recherche ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "384",
+                            "uri": "/selfcnil/api/configuration/site/document/384"
+                        },
+                        "relevance": 95.1923076923077,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 90.5503944323691,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 24.809520442342446,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "214",
+                            "uri": "/selfcnil/api/configuration/site/document/214"
+                        },
+                        "relevance": 24.809520442342446,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "198",
+                            "uri": "/selfcnil/api/configuration/site/document/198"
+                        },
+                        "relevance": 24.80011822387855,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 24.798556117564377,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "209",
+                            "uri": "/selfcnil/api/configuration/site/document/209"
+                        },
+                        "relevance": 24.796994011250206,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 24.792319178383533,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "234",
+                            "uri": "/selfcnil/api/configuration/site/document/234"
+                        },
+                        "relevance": 24.79231697557447,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "317",
+                            "uri": "/selfcnil/api/configuration/site/document/317"
+                        },
+                        "relevance": 24.79231697557447,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Qu'est-ce qu'un moteur de recherche ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "208",
+                            "uri": "/selfcnil/api/configuration/site/document/208"
+                        },
+                        "relevance": 95.2,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 24.952589746662145,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 24.876294873331073,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "198",
+                            "uri": "/selfcnil/api/configuration/site/document/198"
+                        },
+                        "relevance": 24.87629487333107,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 24.8,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 393,
+        "epitca": [
+            {
+                "question": "Dois-je d\u00e9clarer on site web ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 95.58823529411765,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 36.90203869268763,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 29.328422860918167,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 29.32840931785628,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "366",
+                            "uri": "/selfcnil/api/configuration/site/document/366"
+                        },
+                        "relevance": 29.32840818926779,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 29.32840818926779,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 29.32840818926779,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "227",
+                            "uri": "/selfcnil/api/configuration/site/document/227"
+                        },
+                        "relevance": 29.32840818926779,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 29.32840818926779,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 29.3284070606793,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "La CNIL doit-elle \u00eatre avertie de la cr\u00e9ation d'un site web ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 95.25706940874036,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "396",
+                            "uri": "/selfcnil/api/configuration/site/document/396"
+                        },
+                        "relevance": 87.65139473181976,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "864",
+                            "uri": "/selfcnil/api/configuration/site/document/864"
+                        },
+                        "relevance": 85.48796470741993,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 85.17980681225636,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "844",
+                            "uri": "/selfcnil/api/configuration/site/document/844"
+                        },
+                        "relevance": 85.03482153222996,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 84.81081079523096,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 84.76172988904602,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 84.70519137593041,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 84.67939205220904,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 84.5943680169089,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Aupr\u00e8s de qui dois-je d\u00e9clarer mon site ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 95.21739130434783,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 26.484717528138518,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "358",
+                            "uri": "/selfcnil/api/configuration/site/document/358"
+                        },
+                        "relevance": 26.4348537145443,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "362",
+                            "uri": "/selfcnil/api/configuration/site/document/362"
+                        },
+                        "relevance": 26.4348537145443,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 26.4348537145443,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "184",
+                            "uri": "/selfcnil/api/configuration/site/document/184"
+                        },
+                        "relevance": 26.370459752396336,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "168",
+                            "uri": "/selfcnil/api/configuration/site/document/168"
+                        },
+                        "relevance": 26.340643668716062,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 26.26894374914625,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "771",
+                            "uri": "/selfcnil/api/configuration/site/document/771"
+                        },
+                        "relevance": 26.26870531315506,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "551",
+                            "uri": "/selfcnil/api/configuration/site/document/551"
+                        },
+                        "relevance": 26.268538297589107,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 401,
+        "epitca": [
+            {
+                "question": "Combien de temps les condamnations sont-elle inscrites dans mon casier ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "401",
+                            "uri": "/selfcnil/api/configuration/site/document/401"
+                        },
+                        "relevance": 95.76923076923077,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "239",
+                            "uri": "/selfcnil/api/configuration/site/document/239"
+                        },
+                        "relevance": 38.43035445140419,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "311",
+                            "uri": "/selfcnil/api/configuration/site/document/311"
+                        },
+                        "relevance": 38.29726287434999,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 38.29692878534909,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 38.29682946159206,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 38.29682494687584,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 38.296793343862234,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "234",
+                            "uri": "/selfcnil/api/configuration/site/document/234"
+                        },
+                        "relevance": 25.87392747216822,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "419",
+                            "uri": "/selfcnil/api/configuration/site/document/419"
+                        },
+                        "relevance": 25.599584518224177,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 25.527675605214185,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Qulle dur\u00e9e d'inscription des donn\u00e9es dans mon casier judiciaire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "239",
+                            "uri": "/selfcnil/api/configuration/site/document/239"
+                        },
+                        "relevance": 95.21413276231263,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "704",
+                            "uri": "/selfcnil/api/configuration/site/document/704"
+                        },
+                        "relevance": 87.97352384456237,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "750",
+                            "uri": "/selfcnil/api/configuration/site/document/750"
+                        },
+                        "relevance": 87.31191377146924,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "237",
+                            "uri": "/selfcnil/api/configuration/site/document/237"
+                        },
+                        "relevance": 87.17595890402777,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "240",
+                            "uri": "/selfcnil/api/configuration/site/document/240"
+                        },
+                        "relevance": 87.10556415427698,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "401",
+                            "uri": "/selfcnil/api/configuration/site/document/401"
+                        },
+                        "relevance": 87.03389700585551,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 84.4479364438839,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 84.42648626608367,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 84.1345592868478,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 84.11558445520566,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Au bout de combien de temps mon casier judiciaire est-il vierge ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "239",
+                            "uri": "/selfcnil/api/configuration/site/document/239"
+                        },
+                        "relevance": 95.18691588785046,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "704",
+                            "uri": "/selfcnil/api/configuration/site/document/704"
+                        },
+                        "relevance": 91.93025901522685,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "750",
+                            "uri": "/selfcnil/api/configuration/site/document/750"
+                        },
+                        "relevance": 91.31489206219133,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "240",
+                            "uri": "/selfcnil/api/configuration/site/document/240"
+                        },
+                        "relevance": 90.4744215471204,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "237",
+                            "uri": "/selfcnil/api/configuration/site/document/237"
+                        },
+                        "relevance": 87.35632740248661,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "401",
+                            "uri": "/selfcnil/api/configuration/site/document/401"
+                        },
+                        "relevance": 87.12605459202184,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 84.52024690499594,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 84.07932399543454,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "204",
+                            "uri": "/selfcnil/api/configuration/site/document/204"
+                        },
+                        "relevance": 83.57934427936928,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 83.57217730630626,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 403,
+        "epitca": [
+            {
+                "question": "Peut-on filmer l'interieur des habitations ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "404",
+                            "uri": "/selfcnil/api/configuration/site/document/404"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1551",
+                            "uri": "/selfcnil/api/configuration/site/document/1551"
+                        },
+                        "relevance": 95.9090909090909,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 54.20070991395329,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 54.167258949825914,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 54.16397181763275,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 54.16397181763275,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "174",
+                            "uri": "/selfcnil/api/configuration/site/document/174"
+                        },
+                        "relevance": 33.98092052355612,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "583",
+                            "uri": "/selfcnil/api/configuration/site/document/583"
+                        },
+                        "relevance": 32.742189932901596,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "844",
+                            "uri": "/selfcnil/api/configuration/site/document/844"
+                        },
+                        "relevance": 32.742189932901596,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "553",
+                            "uri": "/selfcnil/api/configuration/site/document/553"
+                        },
+                        "relevance": 32.32053713070186,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Les autorit\u00e9s ont-elle le droit de filmer chez moi ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "333",
+                            "uri": "/selfcnil/api/configuration/site/document/333"
+                        },
+                        "relevance": 95.27777777777777,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 86.45994269181887,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 86.45994269181887,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 82.29426835682686,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1542",
+                            "uri": "/selfcnil/api/configuration/site/document/1542"
+                        },
+                        "relevance": 25.585281176527314,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "607",
+                            "uri": "/selfcnil/api/configuration/site/document/607"
+                        },
+                        "relevance": 25.444824586631142,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "844",
+                            "uri": "/selfcnil/api/configuration/site/document/844"
+                        },
+                        "relevance": 25.23539559630291,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "353",
+                            "uri": "/selfcnil/api/configuration/site/document/353"
+                        },
+                        "relevance": 25.171526078943153,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1398",
+                            "uri": "/selfcnil/api/configuration/site/document/1398"
+                        },
+                        "relevance": 25.07318068029386,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1245",
+                            "uri": "/selfcnil/api/configuration/site/document/1245"
+                        },
+                        "relevance": 25.07318068029386,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Est-il autoris\u00e9 de filmer l'int\u00e9rieur de mon domicile ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "404",
+                            "uri": "/selfcnil/api/configuration/site/document/404"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1551",
+                            "uri": "/selfcnil/api/configuration/site/document/1551"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 43.215541833048015,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 43.20143721543115,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 43.200051771548374,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 43.200051771548374,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 43.17324900362507,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 43.17323008254018,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 43.17322798019741,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 43.17322798019741,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 412,
+        "epitca": [
+            {
+                "question": "Qui regarde les images de vid\u00e9oprotection ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 95.45454545454545,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 95.45445108858326,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "436",
+                            "uri": "/selfcnil/api/configuration/site/document/436"
+                        },
+                        "relevance": 95.45445108858326,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1550",
+                            "uri": "/selfcnil/api/configuration/site/document/1550"
+                        },
+                        "relevance": 89.84742454481737,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "411",
+                            "uri": "/selfcnil/api/configuration/site/document/411"
+                        },
+                        "relevance": 89.84742454481737,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1545",
+                            "uri": "/selfcnil/api/configuration/site/document/1545"
+                        },
+                        "relevance": 78.29390177480711,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "406",
+                            "uri": "/selfcnil/api/configuration/site/document/406"
+                        },
+                        "relevance": 78.29390177480711,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1590",
+                            "uri": "/selfcnil/api/configuration/site/document/1590"
+                        },
+                        "relevance": 51.67397966900833,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1589",
+                            "uri": "/selfcnil/api/configuration/site/document/1589"
+                        },
+                        "relevance": 51.67397966900833,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "409",
+                            "uri": "/selfcnil/api/configuration/site/document/409"
+                        },
+                        "relevance": 51.31836656229878,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Qui a le droit de regarder les images des cam\u00e9ras filmant la voie publique ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "404",
+                            "uri": "/selfcnil/api/configuration/site/document/404"
+                        },
+                        "relevance": 95.25575447570333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 94.97022949255452,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1551",
+                            "uri": "/selfcnil/api/configuration/site/document/1551"
+                        },
+                        "relevance": 94.8415557745896,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 94.5658807695414,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 94.38139036311287,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "583",
+                            "uri": "/selfcnil/api/configuration/site/document/583"
+                        },
+                        "relevance": 94.17860922058804,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 93.96997170603188,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 93.96719166199914,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "167",
+                            "uri": "/selfcnil/api/configuration/site/document/167"
+                        },
+                        "relevance": 93.91400942873109,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 93.8887427857513,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Qui est autoriser \u00e0 consulter les vid\u00e9os des cam\u00e9ras de vid\u00e9osurveillance ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 95.43478260869566,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1550",
+                            "uri": "/selfcnil/api/configuration/site/document/1550"
+                        },
+                        "relevance": 71.81860256205212,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "411",
+                            "uri": "/selfcnil/api/configuration/site/document/411"
+                        },
+                        "relevance": 71.81860256205212,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1589",
+                            "uri": "/selfcnil/api/configuration/site/document/1589"
+                        },
+                        "relevance": 62.51187062789172,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1545",
+                            "uri": "/selfcnil/api/configuration/site/document/1545"
+                        },
+                        "relevance": 62.46180202934622,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "406",
+                            "uri": "/selfcnil/api/configuration/site/document/406"
+                        },
+                        "relevance": 62.46180202934622,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "409",
+                            "uri": "/selfcnil/api/configuration/site/document/409"
+                        },
+                        "relevance": 44.130307680468995,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1590",
+                            "uri": "/selfcnil/api/configuration/site/document/1590"
+                        },
+                        "relevance": 43.74822639033557,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 43.56378227542432,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 43.56378227542432,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 427,
+        "epitca": [
+            {
+                "question": "Qui a le droit de manipuler des donn\u00e9es de sant\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 95.11494252873563,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "424",
+                            "uri": "/selfcnil/api/configuration/site/document/424"
+                        },
+                        "relevance": 81.28598187579456,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "426",
+                            "uri": "/selfcnil/api/configuration/site/document/426"
+                        },
+                        "relevance": 80.581334493304,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1337",
+                            "uri": "/selfcnil/api/configuration/site/document/1337"
+                        },
+                        "relevance": 75.12690858028249,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "429",
+                            "uri": "/selfcnil/api/configuration/site/document/429"
+                        },
+                        "relevance": 71.68263191990353,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "425",
+                            "uri": "/selfcnil/api/configuration/site/document/425"
+                        },
+                        "relevance": 67.24821397912076,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "434",
+                            "uri": "/selfcnil/api/configuration/site/document/434"
+                        },
+                        "relevance": 65.23166099669426,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "427",
+                            "uri": "/selfcnil/api/configuration/site/document/427"
+                        },
+                        "relevance": 59.450317299524045,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "428",
+                            "uri": "/selfcnil/api/configuration/site/document/428"
+                        },
+                        "relevance": 59.42025946853956,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "478",
+                            "uri": "/selfcnil/api/configuration/site/document/478"
+                        },
+                        "relevance": 56.0496242794985,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Qui est autoriser \u00e0 traiter des donn\u00e9es de sant\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 94.27636797125845,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 94.27451304001187,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 65.93389671256408,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "532",
+                            "uri": "/selfcnil/api/configuration/site/document/532"
+                        },
+                        "relevance": 50.21480495269177,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "584",
+                            "uri": "/selfcnil/api/configuration/site/document/584"
+                        },
+                        "relevance": 50.14276756671213,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1254",
+                            "uri": "/selfcnil/api/configuration/site/document/1254"
+                        },
+                        "relevance": 44.76182506773086,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1338",
+                            "uri": "/selfcnil/api/configuration/site/document/1338"
+                        },
+                        "relevance": 43.6416110765692,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 38.620763709797814,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1337",
+                            "uri": "/selfcnil/api/configuration/site/document/1337"
+                        },
+                        "relevance": 8.861438201376588,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Qui est autoris\u00e9 \u00e0 acc\u00e9der aux donn\u00e9es de sant\u00e9 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 95.83333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "440",
+                            "uri": "/selfcnil/api/configuration/site/document/440"
+                        },
+                        "relevance": 62.51451699154701,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "439",
+                            "uri": "/selfcnil/api/configuration/site/document/439"
+                        },
+                        "relevance": 53.790326588287996,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "438",
+                            "uri": "/selfcnil/api/configuration/site/document/438"
+                        },
+                        "relevance": 53.78925383527926,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "265",
+                            "uri": "/selfcnil/api/configuration/site/document/265"
+                        },
+                        "relevance": 40.24442808024123,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "442",
+                            "uri": "/selfcnil/api/configuration/site/document/442"
+                        },
+                        "relevance": 39.60068858910345,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "437",
+                            "uri": "/selfcnil/api/configuration/site/document/437"
+                        },
+                        "relevance": 39.60068858910345,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "443",
+                            "uri": "/selfcnil/api/configuration/site/document/443"
+                        },
+                        "relevance": 35.05742129461364,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 33.90354798454097,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 25.435997832810912,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 448,
+        "epitca": [
+            {
+                "question": "A quelles informations mon m\u00e9decin peut-il acc\u00e9der ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "448",
+                            "uri": "/selfcnil/api/configuration/site/document/448"
+                        },
+                        "relevance": 95.45454545454545,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 71.88287960315965,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 35.90618901362194,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 35.86096101655308,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 35.86088343185726,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 35.8608758005757,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 35.8608758005757,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 35.86085290673104,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 35.86085036297052,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 35.86083891604818,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "A quoi mon m\u00e9decin a-t-il le droit d'acc\u00e9der ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "430",
+                            "uri": "/selfcnil/api/configuration/site/document/430"
+                        },
+                        "relevance": 95.4,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 91.35731540055052,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "440",
+                            "uri": "/selfcnil/api/configuration/site/document/440"
+                        },
+                        "relevance": 83.05924168961438,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "265",
+                            "uri": "/selfcnil/api/configuration/site/document/265"
+                        },
+                        "relevance": 76.32756566781414,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 35.69717624410827,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 35.69717624410827,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 35.67447435762519,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 35.66314150765536,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 35.66314150765536,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 35.64614287888889,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Mon m\u00e9decin peut-il acc\u00e9der \u00e0 toutes mes information de remboursement ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "430",
+                            "uri": "/selfcnil/api/configuration/site/document/430"
+                        },
+                        "relevance": 95.4,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 94.06233299829312,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "307",
+                            "uri": "/selfcnil/api/configuration/site/document/307"
+                        },
+                        "relevance": 61.97521158186651,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "437",
+                            "uri": "/selfcnil/api/configuration/site/document/437"
+                        },
+                        "relevance": 61.540564012601074,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "476",
+                            "uri": "/selfcnil/api/configuration/site/document/476"
+                        },
+                        "relevance": 56.37727545846056,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "477",
+                            "uri": "/selfcnil/api/configuration/site/document/477"
+                        },
+                        "relevance": 56.37727545846056,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1349",
+                            "uri": "/selfcnil/api/configuration/site/document/1349"
+                        },
+                        "relevance": 54.752865646403656,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "440",
+                            "uri": "/selfcnil/api/configuration/site/document/440"
+                        },
+                        "relevance": 53.43563331371774,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "439",
+                            "uri": "/selfcnil/api/configuration/site/document/439"
+                        },
+                        "relevance": 53.43563331371774,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 50.79792334748981,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 492,
+        "epitca": [
+            {
+                "question": "Quelle est la d\u00e9finition d'une donn\u00e9es personnelle ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 69.75672029668688,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 43.557730969673266,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 43.55766866016194,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 43.55760420204677,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 43.557490326043315,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1327",
+                            "uri": "/selfcnil/api/configuration/site/document/1327"
+                        },
+                        "relevance": 37.81734444918608,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 37.44427282310073,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 37.15559642556618,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1368",
+                            "uri": "/selfcnil/api/configuration/site/document/1368"
+                        },
+                        "relevance": 25.323098144639,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "C'est quoi une information personnelle ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "214",
+                            "uri": "/selfcnil/api/configuration/site/document/214"
+                        },
+                        "relevance": 95.390625,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 89.36296946746727,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 88.75773646955699,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 87.98204979222615,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 86.12484738261197,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 85.6208946349371,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 85.57061398654199,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 43.86696612628376,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1367",
+                            "uri": "/selfcnil/api/configuration/site/document/1367"
+                        },
+                        "relevance": 41.04743775068346,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 36.59692841003412,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Qu'est ce qu'une donn\u00e9e personnelle ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 95.13888888888889,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 94.3792927992207,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 81.63299155278473,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 81.6215058601807,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 81.61216637636026,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 81.59369413883937,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1433",
+                            "uri": "/selfcnil/api/configuration/site/document/1433"
+                        },
+                        "relevance": 38.89355306666201,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "424",
+                            "uri": "/selfcnil/api/configuration/site/document/424"
+                        },
+                        "relevance": 32.41550044247364,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "182",
+                            "uri": "/selfcnil/api/configuration/site/document/182"
+                        },
+                        "relevance": 31.339818604289015,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 30.65927711981018,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 494,
+        "epitca": [
+            {
+                "question": "C'est quoi traiter des donn\u00e9es personnelles ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 95.76923076923077,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 90.14393410241901,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 81.15650861786135,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 80.94082429369118,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 80.9408159335094,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 80.94080728504548,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 80.94079635738028,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 80.94079200609256,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 80.94079027639978,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1308",
+                            "uri": "/selfcnil/api/configuration/site/document/1308"
+                        },
+                        "relevance": 31.22919106879246,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Un traitement de donn\u00e9es personnelles qu'est ce que c'est ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 95.7936507936508,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 81.68498521022812,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 81.47237039621426,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 81.47236726064166,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 81.47236047815016,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 81.47235340076774,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 31.068693518103828,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "424",
+                            "uri": "/selfcnil/api/configuration/site/document/424"
+                        },
+                        "relevance": 31.00899583996748,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 30.46371334241825,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 30.323067897121785,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "C'est quoi un traitement de donn\u00e9es \u00e0 caract\u00e8re personnel ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 95.125,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 41.55732774335503,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 24.72502674463792,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 24.72502080138505,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 24.72502080138505,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 24.72501485813218,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 24.725010400692526,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 24.725,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 495,
+        "epitca": [
+            {
+                "question": "Qu'est-ce qu'une donn\u00e9e sensible ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 95.17241379310344,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 39.605580275343215,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 38.1389938253486,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 33.25546221934542,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 33.175858960639914,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 33.12540936532679,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "61",
+                            "uri": "/selfcnil/api/configuration/site/document/61"
+                        },
+                        "relevance": 33.10872185230003,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 33.10694139362888,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "219",
+                            "uri": "/selfcnil/api/configuration/site/document/219"
+                        },
+                        "relevance": 33.10694139362888,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 33.10694139362888,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quelle est la d\u00e9finition d'une donn\u00e9es sensible ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 95.23255813953489,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 37.3782159030868,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 34.394180054757804,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 34.39409620751419,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 34.394075245703284,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 34.394075245703284,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 34.39406476479783,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 34.39406476479783,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 34.39405428389238,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 34.39405428389238,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "C'est quoi une donn\u00e9e sensible ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 95.23255813953489,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 37.42961955279469,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 34.44204860667509,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 34.44201138963365,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 34.44199394414547,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 34.44199394414547,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 34.441990455047836,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "500",
+                            "uri": "/selfcnil/api/configuration/site/document/500"
+                        },
+                        "relevance": 34.441990455047836,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 34.4419869659502,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 34.4419869659502,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 512,
+        "epitca": [
+            {
+                "question": "Qu'est-ce que le droit d'acc\u00e8s ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 95.11904761904762,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1436",
+                            "uri": "/selfcnil/api/configuration/site/document/1436"
+                        },
+                        "relevance": 81.37128420608504,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "518",
+                            "uri": "/selfcnil/api/configuration/site/document/518"
+                        },
+                        "relevance": 81.37127880859119,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "513",
+                            "uri": "/selfcnil/api/configuration/site/document/513"
+                        },
+                        "relevance": 80.29917417914591,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1546",
+                            "uri": "/selfcnil/api/configuration/site/document/1546"
+                        },
+                        "relevance": 69.55488490632791,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1544",
+                            "uri": "/selfcnil/api/configuration/site/document/1544"
+                        },
+                        "relevance": 69.55488490632791,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 29.086393321112467,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "672",
+                            "uri": "/selfcnil/api/configuration/site/document/672"
+                        },
+                        "relevance": 29.073598353836676,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 29.073598353836676,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 28.794348141968822,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Ai-je le droit de conna\u00eetre les informations d\u00e9tenues sur moi ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "354",
+                            "uri": "/selfcnil/api/configuration/site/document/354"
+                        },
+                        "relevance": 95.20746887966806,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "237",
+                            "uri": "/selfcnil/api/configuration/site/document/237"
+                        },
+                        "relevance": 94.39522575001698,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 88.46466394741493,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 88.30209966046621,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 88.22751300302235,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 87.7551192494025,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "204",
+                            "uri": "/selfcnil/api/configuration/site/document/204"
+                        },
+                        "relevance": 87.70077441691382,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 87.68366666325659,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 87.4269599228062,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 87.41606434636456,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "C'est quoi le droit d'acc\u00e8s ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 95.11235955056179,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1436",
+                            "uri": "/selfcnil/api/configuration/site/document/1436"
+                        },
+                        "relevance": 81.43787129507496,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "518",
+                            "uri": "/selfcnil/api/configuration/site/document/518"
+                        },
+                        "relevance": 81.4378631453594,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "513",
+                            "uri": "/selfcnil/api/configuration/site/document/513"
+                        },
+                        "relevance": 80.3682207280369,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1546",
+                            "uri": "/selfcnil/api/configuration/site/document/1546"
+                        },
+                        "relevance": 71.06965484839586,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1544",
+                            "uri": "/selfcnil/api/configuration/site/document/1544"
+                        },
+                        "relevance": 71.06965484839586,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 28.40762757475186,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "672",
+                            "uri": "/selfcnil/api/configuration/site/document/672"
+                        },
+                        "relevance": 28.38643872661473,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "812",
+                            "uri": "/selfcnil/api/configuration/site/document/812"
+                        },
+                        "relevance": 28.38643872661473,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 28.368106909907713,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 533,
+        "epitca": [
+            {
+                "question": "Qu'est ce que la CNIL ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "864",
+                            "uri": "/selfcnil/api/configuration/site/document/864"
+                        },
+                        "relevance": 95.30581039755351,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 94.28082927898215,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "844",
+                            "uri": "/selfcnil/api/configuration/site/document/844"
+                        },
+                        "relevance": 92.68760217808472,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "228",
+                            "uri": "/selfcnil/api/configuration/site/document/228"
+                        },
+                        "relevance": 89.41073996550466,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 88.9010757646059,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 88.26651573972035,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 85.74286197584988,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 85.47914191039884,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 85.00456958591953,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 84.65392139980582,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Que fait la CNIL ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 95.5464480874317,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 93.6566657624334,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 91.319769281384,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "240",
+                            "uri": "/selfcnil/api/configuration/site/document/240"
+                        },
+                        "relevance": 88.97166662743996,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 87.7697367992411,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1538",
+                            "uri": "/selfcnil/api/configuration/site/document/1538"
+                        },
+                        "relevance": 86.05678162696306,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "904",
+                            "uri": "/selfcnil/api/configuration/site/document/904"
+                        },
+                        "relevance": 86.05678162696306,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "84",
+                            "uri": "/selfcnil/api/configuration/site/document/84"
+                        },
+                        "relevance": 86.0567804427374,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1398",
+                            "uri": "/selfcnil/api/configuration/site/document/1398"
+                        },
+                        "relevance": 83.14189248169636,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "228",
+                            "uri": "/selfcnil/api/configuration/site/document/228"
+                        },
+                        "relevance": 29.42418853362388,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "A quoi sert la CNIL ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 90.7530555606358,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1261",
+                            "uri": "/selfcnil/api/configuration/site/document/1261"
+                        },
+                        "relevance": 33.82321070396198,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "269",
+                            "uri": "/selfcnil/api/configuration/site/document/269"
+                        },
+                        "relevance": 32.98743690565425,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "853",
+                            "uri": "/selfcnil/api/configuration/site/document/853"
+                        },
+                        "relevance": 32.34395448433213,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1529",
+                            "uri": "/selfcnil/api/configuration/site/document/1529"
+                        },
+                        "relevance": 32.31296914627925,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 32.15227745280913,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 32.02016888361079,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1363",
+                            "uri": "/selfcnil/api/configuration/site/document/1363"
+                        },
+                        "relevance": 32.02015588454431,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1264",
+                            "uri": "/selfcnil/api/configuration/site/document/1264"
+                        },
+                        "relevance": 32.02008730582844,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1260",
+                            "uri": "/selfcnil/api/configuration/site/document/1260"
+                        },
+                        "relevance": 31.74037163876968,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 540,
+        "epitca": [
+            {
+                "question": "Utilisation du NIR par les assureurs",
+                "result": [
+                    {
+                        "document": {
+                            "id": "540",
+                            "uri": "/selfcnil/api/configuration/site/document/540"
+                        },
+                        "relevance": 95.66666666666667,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 60.76960266251492,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 60.76960266251492,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 60.76960266251492,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "465",
+                            "uri": "/selfcnil/api/configuration/site/document/465"
+                        },
+                        "relevance": 29.730720568554847,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "464",
+                            "uri": "/selfcnil/api/configuration/site/document/464"
+                        },
+                        "relevance": 29.21532019921021,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 29.15050258781558,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "167",
+                            "uri": "/selfcnil/api/configuration/site/document/167"
+                        },
+                        "relevance": 28.423168945979775,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "583",
+                            "uri": "/selfcnil/api/configuration/site/document/583"
+                        },
+                        "relevance": 28.391705741276912,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "844",
+                            "uri": "/selfcnil/api/configuration/site/document/844"
+                        },
+                        "relevance": 28.391705741276912,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment consulter le RNIPP quand on est assureur ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "540",
+                            "uri": "/selfcnil/api/configuration/site/document/540"
+                        },
+                        "relevance": 95.87719298245614,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 82.12020825580444,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 82.12020825135593,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 82.08241434742753,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 82.08241434742753,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 25.477198085753177,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1261",
+                            "uri": "/selfcnil/api/configuration/site/document/1261"
+                        },
+                        "relevance": 25.477195278939814,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 25.477195151357378,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "288",
+                            "uri": "/selfcnil/api/configuration/site/document/288"
+                        },
+                        "relevance": 25.477194768610108,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "331",
+                            "uri": "/selfcnil/api/configuration/site/document/331"
+                        },
+                        "relevance": 25.477194768610108,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment utiliser le NIR quand on est assureur ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "465",
+                            "uri": "/selfcnil/api/configuration/site/document/465"
+                        },
+                        "relevance": 95.3225806451613,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "464",
+                            "uri": "/selfcnil/api/configuration/site/document/464"
+                        },
+                        "relevance": 89.81793679845799,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "540",
+                            "uri": "/selfcnil/api/configuration/site/document/540"
+                        },
+                        "relevance": 84.63024493595559,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 81.97413759401705,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "466",
+                            "uri": "/selfcnil/api/configuration/site/document/466"
+                        },
+                        "relevance": 81.33706854683787,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 56.114908811235445,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "785",
+                            "uri": "/selfcnil/api/configuration/site/document/785"
+                        },
+                        "relevance": 56.114908811235445,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "469",
+                            "uri": "/selfcnil/api/configuration/site/document/469"
+                        },
+                        "relevance": 37.856208279026106,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "872",
+                            "uri": "/selfcnil/api/configuration/site/document/872"
+                        },
+                        "relevance": 26.763267140235325,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 26.763111486765062,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 541,
+        "epitca": [
+            {
+                "question": "Comment g\u00e9rer un fichier client ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 95.38461538461539,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "521",
+                            "uri": "/selfcnil/api/configuration/site/document/521"
+                        },
+                        "relevance": 42.37567276948,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 37.70837382101183,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 37.70837382101183,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1368",
+                            "uri": "/selfcnil/api/configuration/site/document/1368"
+                        },
+                        "relevance": 31.42477923275584,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "523",
+                            "uri": "/selfcnil/api/configuration/site/document/523"
+                        },
+                        "relevance": 31.32780102243398,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "536",
+                            "uri": "/selfcnil/api/configuration/site/document/536"
+                        },
+                        "relevance": 31.32780102243398,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 31.326842706235762,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 29.89424094785515,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "343",
+                            "uri": "/selfcnil/api/configuration/site/document/343"
+                        },
+                        "relevance": 29.89424094785515,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment dois-je organiser mon fichier de gestion des clients et des prospects ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "688",
+                            "uri": "/selfcnil/api/configuration/site/document/688"
+                        },
+                        "relevance": 95.14285714285714,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 63.66063826233741,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "521",
+                            "uri": "/selfcnil/api/configuration/site/document/521"
+                        },
+                        "relevance": 58.708644746730734,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 43.222735742537466,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "527",
+                            "uri": "/selfcnil/api/configuration/site/document/527"
+                        },
+                        "relevance": 31.06067183000366,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "528",
+                            "uri": "/selfcnil/api/configuration/site/document/528"
+                        },
+                        "relevance": 28.633846017499685,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1269",
+                            "uri": "/selfcnil/api/configuration/site/document/1269"
+                        },
+                        "relevance": 24.742857142857144,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment dois-je d\u00e9clarer mon fichier clients ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 95.33333333333333,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "773",
+                            "uri": "/selfcnil/api/configuration/site/document/773"
+                        },
+                        "relevance": 50.18051446537671,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1381",
+                            "uri": "/selfcnil/api/configuration/site/document/1381"
+                        },
+                        "relevance": 5.333333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 546,
+        "epitca": [
+            {
+                "question": "Comment g\u00e9rer le fichier patient de mon cabinet m\u00e9dical ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 95.5,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1392",
+                            "uri": "/selfcnil/api/configuration/site/document/1392"
+                        },
+                        "relevance": 85.58272761875344,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 28.39560385813359,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 28.38971635827309,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 28.38853497429889,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 28.38853497429889,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 28.381299402040426,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 28.377952686891582,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 28.377931648546838,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 28.377931648546838,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quelles bonnes pratiques pour le fichiers patient d'un cabinet m\u00e9dical ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 95.27932960893855,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 92.87270063586283,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 92.51112902100321,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "430",
+                            "uri": "/selfcnil/api/configuration/site/document/430"
+                        },
+                        "relevance": 92.28008196552575,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 92.15237463655014,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 91.80533808131268,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 91.80307923801392,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 91.79434683935422,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 91.77376451159984,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "436",
+                            "uri": "/selfcnil/api/configuration/site/document/436"
+                        },
+                        "relevance": 91.74613474678917,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Ou dois-je d\u00e9clarer mon fichier patient ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 95.55555555555556,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "436",
+                            "uri": "/selfcnil/api/configuration/site/document/436"
+                        },
+                        "relevance": 93.8022184062858,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 93.73688273902098,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 56.28069466785399,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 56.28069466785399,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "853",
+                            "uri": "/selfcnil/api/configuration/site/document/853"
+                        },
+                        "relevance": 36.91268457942811,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1340",
+                            "uri": "/selfcnil/api/configuration/site/document/1340"
+                        },
+                        "relevance": 36.745536032457295,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1341",
+                            "uri": "/selfcnil/api/configuration/site/document/1341"
+                        },
+                        "relevance": 36.74496976998722,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1335",
+                            "uri": "/selfcnil/api/configuration/site/document/1335"
+                        },
+                        "relevance": 36.74496976998722,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "773",
+                            "uri": "/selfcnil/api/configuration/site/document/773"
+                        },
+                        "relevance": 36.25918398286036,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 548,
+        "epitca": [
+            {
+                "question": "Quelles modalit\u00e9 de gestion des fichiers de communication politique ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 95.2127659574468,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 38.27511001460131,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 38.27159909456638,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 38.23994485439705,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 35.69973143360791,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 35.67211446272961,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 35.66471879212188,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 35.66468049903969,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 35.66468049903969,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 35.663193451014486,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Ou dois-je d\u00e9clarer mon fichier de communication politique ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 95.25,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1245",
+                            "uri": "/selfcnil/api/configuration/site/document/1245"
+                        },
+                        "relevance": 89.97729444299377,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1398",
+                            "uri": "/selfcnil/api/configuration/site/document/1398"
+                        },
+                        "relevance": 89.97729444299377,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 38.79165389891118,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 30.14019273673328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 30.13443714657273,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 30.133282231559754,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 30.133282231559754,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 30.12291805587482,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 30.12291805587482,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quels bonnes pratiques pour la gestion d'un fichier de communication politique ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 95.22522522522523,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 86.80743784464575,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 86.61653235850132,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 86.47791770456364,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 86.36204631094078,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 86.32675828101077,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 86.31332823092356,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 86.27916717428717,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 86.23909582666451,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 86.23382415973529,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 608,
+        "epitca": [
+            {
+                "question": "Quels conseils pour Windows 10 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "608",
+                            "uri": "/selfcnil/api/configuration/site/document/608"
+                        },
+                        "relevance": 95.125,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 49.626774376640995,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 49.62675678847468,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "170",
+                            "uri": "/selfcnil/api/configuration/site/document/170"
+                        },
+                        "relevance": 49.62675092575258,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 49.62672161214206,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "215",
+                            "uri": "/selfcnil/api/configuration/site/document/215"
+                        },
+                        "relevance": 24.725080731675092,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1477",
+                            "uri": "/selfcnil/api/configuration/site/document/1477"
+                        },
+                        "relevance": 24.72502376539158,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "843",
+                            "uri": "/selfcnil/api/configuration/site/document/843"
+                        },
+                        "relevance": 24.725,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Quelles bonnes pratiques pour Windows 10 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "608",
+                            "uri": "/selfcnil/api/configuration/site/document/608"
+                        },
+                        "relevance": 95.25,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "170",
+                            "uri": "/selfcnil/api/configuration/site/document/170"
+                        },
+                        "relevance": 35.448685997999,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "464",
+                            "uri": "/selfcnil/api/configuration/site/document/464"
+                        },
+                        "relevance": 33.68070040317882,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "843",
+                            "uri": "/selfcnil/api/configuration/site/document/843"
+                        },
+                        "relevance": 24.85,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Windows 10 quels sont les risques ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 95.3030303030303,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "499",
+                            "uri": "/selfcnil/api/configuration/site/document/499"
+                        },
+                        "relevance": 92.76151525341118,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "154",
+                            "uri": "/selfcnil/api/configuration/site/document/154"
+                        },
+                        "relevance": 92.24124273329812,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "161",
+                            "uri": "/selfcnil/api/configuration/site/document/161"
+                        },
+                        "relevance": 86.18947899813593,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "215",
+                            "uri": "/selfcnil/api/configuration/site/document/215"
+                        },
+                        "relevance": 85.0298715607607,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "170",
+                            "uri": "/selfcnil/api/configuration/site/document/170"
+                        },
+                        "relevance": 84.32637591441143,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "821",
+                            "uri": "/selfcnil/api/configuration/site/document/821"
+                        },
+                        "relevance": 83.73728824204363,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "464",
+                            "uri": "/selfcnil/api/configuration/site/document/464"
+                        },
+                        "relevance": 70.3397168201499,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 25.039164986191153,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 24.98471033655599,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 831,
+        "epitca": [
+            {
+                "question": "Que faire pour traiter des donn\u00e9es personnelles lors d'\u00e9lections ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "538",
+                            "uri": "/selfcnil/api/configuration/site/document/538"
+                        },
+                        "relevance": 95.26315789473684,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "735",
+                            "uri": "/selfcnil/api/configuration/site/document/735"
+                        },
+                        "relevance": 90.88701612914754,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "195",
+                            "uri": "/selfcnil/api/configuration/site/document/195"
+                        },
+                        "relevance": 83.51380721006471,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 24.8789597857585,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "221",
+                            "uri": "/selfcnil/api/configuration/site/document/221"
+                        },
+                        "relevance": 24.8789597857585,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 24.877127851558463,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 24.876984914017378,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "758",
+                            "uri": "/selfcnil/api/configuration/site/document/758"
+                        },
+                        "relevance": 24.875149090360438,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 24.87501295936893,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 24.87501295936893,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Que doivent mettre en \u0153uvre les partis politiques pour traitrer les donn\u00e9es personnelles lors d'\u00e9lections ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "831",
+                            "uri": "/selfcnil/api/configuration/site/document/831"
+                        },
+                        "relevance": 95.1984126984127,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "830",
+                            "uri": "/selfcnil/api/configuration/site/document/830"
+                        },
+                        "relevance": 91.42131920838064,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 85.35071185588112,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 84.33543120639432,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "204",
+                            "uri": "/selfcnil/api/configuration/site/document/204"
+                        },
+                        "relevance": 84.3239162620904,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 84.16194303638251,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 84.10439539440254,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 84.08153071839975,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 84.0810387443848,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 84.04800762880274,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Elections et donn\u00e9es personnelles, quelles obligations ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "548",
+                            "uri": "/selfcnil/api/configuration/site/document/548"
+                        },
+                        "relevance": 95.47846889952153,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 94.53557561888022,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "831",
+                            "uri": "/selfcnil/api/configuration/site/document/831"
+                        },
+                        "relevance": 88.41637880279018,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "830",
+                            "uri": "/selfcnil/api/configuration/site/document/830"
+                        },
+                        "relevance": 86.19573735287314,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "271",
+                            "uri": "/selfcnil/api/configuration/site/document/271"
+                        },
+                        "relevance": 36.76542549728644,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 36.759680408146366,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 33.514152266757804,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 32.760082341207095,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "175",
+                            "uri": "/selfcnil/api/configuration/site/document/175"
+                        },
+                        "relevance": 31.528522858355352,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1533",
+                            "uri": "/selfcnil/api/configuration/site/document/1533"
+                        },
+                        "relevance": 30.367635965228697,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 832,
+        "epitca": [
+            {
+                "question": "Comment faire des recherches en sant\u00e9 sans le consentement ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 95.3225806451613,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "67",
+                            "uri": "/selfcnil/api/configuration/site/document/67"
+                        },
+                        "relevance": 25.70526379698455,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 25.70525181744261,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 25.70524637219627,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "583",
+                            "uri": "/selfcnil/api/configuration/site/document/583"
+                        },
+                        "relevance": 25.70524637219627,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 25.70524637219627,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 25.705242015999207,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "386",
+                            "uri": "/selfcnil/api/configuration/site/document/386"
+                        },
+                        "relevance": 25.705239837900674,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 25.705235481703603,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 25.705231125506533,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quelles sont les formalit\u00e9s pour mettre en \u0153uvre pour la MR-003 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 95.33333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "909",
+                            "uri": "/selfcnil/api/configuration/site/document/909"
+                        },
+                        "relevance": 24.93348382682534,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "433",
+                            "uri": "/selfcnil/api/configuration/site/document/433"
+                        },
+                        "relevance": 24.933333333333334,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Dans quels cas peut-on mettre en \u0153uvre la MR-003 ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1390",
+                            "uri": "/selfcnil/api/configuration/site/document/1390"
+                        },
+                        "relevance": 95.52631578947368,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1246",
+                            "uri": "/selfcnil/api/configuration/site/document/1246"
+                        },
+                        "relevance": 38.14070823394296,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "832",
+                            "uri": "/selfcnil/api/configuration/site/document/832"
+                        },
+                        "relevance": 38.14070823394296,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 38.13786058089979,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 38.123717930311656,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 38.1237158517328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "436",
+                            "uri": "/selfcnil/api/configuration/site/document/436"
+                        },
+                        "relevance": 38.12365765152461,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 38.12362231568393,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 38.12362231568393,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "477",
+                            "uri": "/selfcnil/api/configuration/site/document/477"
+                        },
+                        "relevance": 25.370854444975993,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1243,
+        "epitca": [
+            {
+                "question": "Comment consulter le fichier des fichiers ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 95.86206896551724,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "312",
+                            "uri": "/selfcnil/api/configuration/site/document/312"
+                        },
+                        "relevance": 81.56150546474028,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "155",
+                            "uri": "/selfcnil/api/configuration/site/document/155"
+                        },
+                        "relevance": 81.53944857453274,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "279",
+                            "uri": "/selfcnil/api/configuration/site/document/279"
+                        },
+                        "relevance": 81.46329097769095,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "378",
+                            "uri": "/selfcnil/api/configuration/site/document/378"
+                        },
+                        "relevance": 81.3211306043109,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "420",
+                            "uri": "/selfcnil/api/configuration/site/document/420"
+                        },
+                        "relevance": 81.32111938826533,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "423",
+                            "uri": "/selfcnil/api/configuration/site/document/423"
+                        },
+                        "relevance": 81.32111257852337,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "323",
+                            "uri": "/selfcnil/api/configuration/site/document/323"
+                        },
+                        "relevance": 67.81431909848433,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "321",
+                            "uri": "/selfcnil/api/configuration/site/document/321"
+                        },
+                        "relevance": 61.17338147720619,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "415",
+                            "uri": "/selfcnil/api/configuration/site/document/415"
+                        },
+                        "relevance": 59.34384466580804,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Comment acc\u00e9der aux informations sur les traitements mis en \u0153uvre avant le RGPD ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 95.22271714922049,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 95.15357099597652,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.11939653220841,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 95.02983881724401,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 94.93444217500537,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 94.9223365687779,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 94.91198201990913,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 94.89048269232944,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 94.88543172208337,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 94.87465128932647,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Peut-on avoir acc\u00e8s au registre des traitement pr\u00e9-RGPD ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1359",
+                            "uri": "/selfcnil/api/configuration/site/document/1359"
+                        },
+                        "relevance": 95.1,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 80.54814499925429,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 80.52973549800019,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 80.15530005468642,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 80.15529918198422,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 80.1552974365798,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 80.15529656387758,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 80.15529656387758,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 80.15529656387758,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 80.15529656387758,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1245,
+        "epitca": [
+            {
+                "question": "Qu'est ce qui me prouve que mon patron respecte le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1245",
+                            "uri": "/selfcnil/api/configuration/site/document/1245"
+                        },
+                        "relevance": 95.125,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 82.69568125784177,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 82.34252518856391,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 82.34250850079836,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1368",
+                            "uri": "/selfcnil/api/configuration/site/document/1368"
+                        },
+                        "relevance": 63.016035659563265,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 31.724727930890385,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1378",
+                            "uri": "/selfcnil/api/configuration/site/document/1378"
+                        },
+                        "relevance": 31.724215899343093,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 31.665970799945615,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1269",
+                            "uri": "/selfcnil/api/configuration/site/document/1269"
+                        },
+                        "relevance": 31.643709200114117,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 31.638064641404622,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment savoir si la soci\u00e9t\u00e9 qui m'emploie respecte le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1308",
+                            "uri": "/selfcnil/api/configuration/site/document/1308"
+                        },
+                        "relevance": 95.58823529411765,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "345",
+                            "uri": "/selfcnil/api/configuration/site/document/345"
+                        },
+                        "relevance": 48.04512037829479,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "346",
+                            "uri": "/selfcnil/api/configuration/site/document/346"
+                        },
+                        "relevance": 47.974604832415714,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "853",
+                            "uri": "/selfcnil/api/configuration/site/document/853"
+                        },
+                        "relevance": 47.93826755691745,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "337",
+                            "uri": "/selfcnil/api/configuration/site/document/337"
+                        },
+                        "relevance": 47.93826755691745,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1342",
+                            "uri": "/selfcnil/api/configuration/site/document/1342"
+                        },
+                        "relevance": 47.92309713889953,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "843",
+                            "uri": "/selfcnil/api/configuration/site/document/843"
+                        },
+                        "relevance": 37.90131098579668,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 37.66710323087351,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "763",
+                            "uri": "/selfcnil/api/configuration/site/document/763"
+                        },
+                        "relevance": 37.13722170923513,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 37.13722170923513,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment puis-je m'assurer que mon employeur respecte le R\u00e8glement europ\u00e9en ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1245",
+                            "uri": "/selfcnil/api/configuration/site/document/1245"
+                        },
+                        "relevance": 95.58823529411765,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1308",
+                            "uri": "/selfcnil/api/configuration/site/document/1308"
+                        },
+                        "relevance": 64.4504303868383,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 48.87209275767504,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 48.71401904443365,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 48.71390010299773,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "352",
+                            "uri": "/selfcnil/api/configuration/site/document/352"
+                        },
+                        "relevance": 48.7138945651057,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 48.71386964459158,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "339",
+                            "uri": "/selfcnil/api/configuration/site/document/339"
+                        },
+                        "relevance": 25.188268357527626,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "269",
+                            "uri": "/selfcnil/api/configuration/site/document/269"
+                        },
+                        "relevance": 25.188260742812567,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "358",
+                            "uri": "/selfcnil/api/configuration/site/document/358"
+                        },
+                        "relevance": 25.188260742812567,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1253,
+        "epitca": [
+            {
+                "question": "Qu'est ce que le RGPD apporte de nouveau ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.2,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 73.34956867088961,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1368",
+                            "uri": "/selfcnil/api/configuration/site/document/1368"
+                        },
+                        "relevance": 17.070902706120812,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1261",
+                            "uri": "/selfcnil/api/configuration/site/document/1261"
+                        },
+                        "relevance": 5.2,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Que faut-il savoir sur le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.65359477124183,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1245",
+                            "uri": "/selfcnil/api/configuration/site/document/1245"
+                        },
+                        "relevance": 81.50418742118556,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1389",
+                            "uri": "/selfcnil/api/configuration/site/document/1389"
+                        },
+                        "relevance": 81.19252620016682,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1368",
+                            "uri": "/selfcnil/api/configuration/site/document/1368"
+                        },
+                        "relevance": 81.13388680537355,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1614",
+                            "uri": "/selfcnil/api/configuration/site/document/1614"
+                        },
+                        "relevance": 77.58715140534808,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1267",
+                            "uri": "/selfcnil/api/configuration/site/document/1267"
+                        },
+                        "relevance": 72.15559029269058,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1392",
+                            "uri": "/selfcnil/api/configuration/site/document/1392"
+                        },
+                        "relevance": 61.92868309311335,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1390",
+                            "uri": "/selfcnil/api/configuration/site/document/1390"
+                        },
+                        "relevance": 46.11729018453126,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 34.241634161710905,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1397",
+                            "uri": "/selfcnil/api/configuration/site/document/1397"
+                        },
+                        "relevance": 33.54326282913629,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Le RGPD c'est quoi ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 95.49019607843137,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "167",
+                            "uri": "/selfcnil/api/configuration/site/document/167"
+                        },
+                        "relevance": 32.939630588191854,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "362",
+                            "uri": "/selfcnil/api/configuration/site/document/362"
+                        },
+                        "relevance": 32.93959990117737,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "497",
+                            "uri": "/selfcnil/api/configuration/site/document/497"
+                        },
+                        "relevance": 32.939436117475786,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 32.93942612357283,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "582",
+                            "uri": "/selfcnil/api/configuration/site/document/582"
+                        },
+                        "relevance": 32.93942518316534,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "647",
+                            "uri": "/selfcnil/api/configuration/site/document/647"
+                        },
+                        "relevance": 32.939424893344594,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 32.939424893344594,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "378",
+                            "uri": "/selfcnil/api/configuration/site/document/378"
+                        },
+                        "relevance": 32.939424893344594,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1264",
+                            "uri": "/selfcnil/api/configuration/site/document/1264"
+                        },
+                        "relevance": 32.939424893344594,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1258,
+        "epitca": [
+            {
+                "question": "Quelle est la responsabilit\u00e9 du DPO en cas de manquement ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1260",
+                            "uri": "/selfcnil/api/configuration/site/document/1260"
+                        },
+                        "relevance": 33.37369578182105,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 33.35901505972712,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 33.16391269801873,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1264",
+                            "uri": "/selfcnil/api/configuration/site/document/1264"
+                        },
+                        "relevance": 33.09761557290454,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1362",
+                            "uri": "/selfcnil/api/configuration/site/document/1362"
+                        },
+                        "relevance": 32.683495638582755,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1531",
+                            "uri": "/selfcnil/api/configuration/site/document/1531"
+                        },
+                        "relevance": 25.396054168205957,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1361",
+                            "uri": "/selfcnil/api/configuration/site/document/1361"
+                        },
+                        "relevance": 25.351078178702892,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "557",
+                            "uri": "/selfcnil/api/configuration/site/document/557"
+                        },
+                        "relevance": 25.349408539478794,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 25.330649874660853,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "167",
+                            "uri": "/selfcnil/api/configuration/site/document/167"
+                        },
+                        "relevance": 25.320100695724822,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Un DPO peut-il \u00eatre sanctionn\u00e9 ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1387",
+                            "uri": "/selfcnil/api/configuration/site/document/1387"
+                        },
+                        "relevance": 95.67114093959732,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1393",
+                            "uri": "/selfcnil/api/configuration/site/document/1393"
+                        },
+                        "relevance": 88.29466448125272,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1357",
+                            "uri": "/selfcnil/api/configuration/site/document/1357"
+                        },
+                        "relevance": 83.29199430519566,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 83.29078181294122,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1260",
+                            "uri": "/selfcnil/api/configuration/site/document/1260"
+                        },
+                        "relevance": 83.26544991122145,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1264",
+                            "uri": "/selfcnil/api/configuration/site/document/1264"
+                        },
+                        "relevance": 83.25911766236678,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1529",
+                            "uri": "/selfcnil/api/configuration/site/document/1529"
+                        },
+                        "relevance": 83.22582113786919,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1363",
+                            "uri": "/selfcnil/api/configuration/site/document/1363"
+                        },
+                        "relevance": 83.20146257507969,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 83.19516779194397,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 83.17616930159932,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Le d\u00e9l\u00e9gu\u00e9 \u00e0 la protection des donn\u00e9es d'une entreprise peut-il \u00eatre poursuivi ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "259",
+                            "uri": "/selfcnil/api/configuration/site/document/259"
+                        },
+                        "relevance": 95.73529411764706,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "342",
+                            "uri": "/selfcnil/api/configuration/site/document/342"
+                        },
+                        "relevance": 84.51634576263298,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "538",
+                            "uri": "/selfcnil/api/configuration/site/document/538"
+                        },
+                        "relevance": 62.35922697005528,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 43.757005475410146,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "370",
+                            "uri": "/selfcnil/api/configuration/site/document/370"
+                        },
+                        "relevance": 33.51564342190773,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "372",
+                            "uri": "/selfcnil/api/configuration/site/document/372"
+                        },
+                        "relevance": 33.51197747235936,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "369",
+                            "uri": "/selfcnil/api/configuration/site/document/369"
+                        },
+                        "relevance": 33.17407189503185,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1387",
+                            "uri": "/selfcnil/api/configuration/site/document/1387"
+                        },
+                        "relevance": 31.807462445868794,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1351",
+                            "uri": "/selfcnil/api/configuration/site/document/1351"
+                        },
+                        "relevance": 29.21423355724165,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1393",
+                            "uri": "/selfcnil/api/configuration/site/document/1393"
+                        },
+                        "relevance": 29.068948193034576,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1262,
+        "epitca": [
+            {
+                "question": "Le DPO doit-il \u00eatre interne ou externe \u00e0 la soci\u00e9t\u00e9 qui l'emploie ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "280",
+                            "uri": "/selfcnil/api/configuration/site/document/280"
+                        },
+                        "relevance": 95.14285714285714,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 83.97007801520904,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 25.466356299708696,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 24.745301412688427,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "103",
+                            "uri": "/selfcnil/api/configuration/site/document/103"
+                        },
+                        "relevance": 24.745301412688427,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 24.742857142857144,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "425",
+                            "uri": "/selfcnil/api/configuration/site/document/425"
+                        },
+                        "relevance": 24.742857142857144,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Le DPO doit-il \u00eatre un salari\u00e9 de l'entreprise ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "366",
+                            "uri": "/selfcnil/api/configuration/site/document/366"
+                        },
+                        "relevance": 95.83333333333333,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1264",
+                            "uri": "/selfcnil/api/configuration/site/document/1264"
+                        },
+                        "relevance": 85.13794603894773,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "169",
+                            "uri": "/selfcnil/api/configuration/site/document/169"
+                        },
+                        "relevance": 60.18879491973216,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 60.18869851913675,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "167",
+                            "uri": "/selfcnil/api/configuration/site/document/167"
+                        },
+                        "relevance": 60.188614168615786,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "587",
+                            "uri": "/selfcnil/api/configuration/site/document/587"
+                        },
+                        "relevance": 27.94759858143995,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "582",
+                            "uri": "/selfcnil/api/configuration/site/document/582"
+                        },
+                        "relevance": 27.94759858143995,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "345",
+                            "uri": "/selfcnil/api/configuration/site/document/345"
+                        },
+                        "relevance": 25.433333333333337,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "337",
+                            "uri": "/selfcnil/api/configuration/site/document/337"
+                        },
+                        "relevance": 25.433333333333337,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 25.433333333333337,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Quel doit \u00eatre le statut d'un d\u00e9l\u00e9gu\u00e9 \u00e0 la protection des donn\u00e9es ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 95.37037037037037,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 81.33385064453564,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 69.82185665457034,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "572",
+                            "uri": "/selfcnil/api/configuration/site/document/572"
+                        },
+                        "relevance": 69.82185665457034,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "582",
+                            "uri": "/selfcnil/api/configuration/site/document/582"
+                        },
+                        "relevance": 67.78209185892645,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "587",
+                            "uri": "/selfcnil/api/configuration/site/document/587"
+                        },
+                        "relevance": 67.78209185892645,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1340",
+                            "uri": "/selfcnil/api/configuration/site/document/1340"
+                        },
+                        "relevance": 67.73684660423268,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1341",
+                            "uri": "/selfcnil/api/configuration/site/document/1341"
+                        },
+                        "relevance": 67.72724701419179,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1335",
+                            "uri": "/selfcnil/api/configuration/site/document/1335"
+                        },
+                        "relevance": 67.72724701419179,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "853",
+                            "uri": "/selfcnil/api/configuration/site/document/853"
+                        },
+                        "relevance": 67.72724701419179,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1326,
+        "epitca": [
+            {
+                "question": "Les PME doivent elle respecter le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.2,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "584",
+                            "uri": "/selfcnil/api/configuration/site/document/584"
+                        },
+                        "relevance": 30.873565820281467,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "582",
+                            "uri": "/selfcnil/api/configuration/site/document/582"
+                        },
+                        "relevance": 28.075764250749753,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "587",
+                            "uri": "/selfcnil/api/configuration/site/document/587"
+                        },
+                        "relevance": 28.075764250749753,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1341",
+                            "uri": "/selfcnil/api/configuration/site/document/1341"
+                        },
+                        "relevance": 28.07184936235511,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1340",
+                            "uri": "/selfcnil/api/configuration/site/document/1340"
+                        },
+                        "relevance": 28.07184936235511,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "572",
+                            "uri": "/selfcnil/api/configuration/site/document/572"
+                        },
+                        "relevance": 28.07184936235511,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "551",
+                            "uri": "/selfcnil/api/configuration/site/document/551"
+                        },
+                        "relevance": 28.07184936235511,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1335",
+                            "uri": "/selfcnil/api/configuration/site/document/1335"
+                        },
+                        "relevance": 28.07184936235511,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1332",
+                            "uri": "/selfcnil/api/configuration/site/document/1332"
+                        },
+                        "relevance": 28.07184936235511,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Les petites entreprises ont-elles des obligations vis-\u00e0-vis du RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.17241379310344,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 93.43726616442335,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 93.43634088591472,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "167",
+                            "uri": "/selfcnil/api/configuration/site/document/167"
+                        },
+                        "relevance": 93.4361168991864,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "843",
+                            "uri": "/selfcnil/api/configuration/site/document/843"
+                        },
+                        "relevance": 39.558758185922514,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "582",
+                            "uri": "/selfcnil/api/configuration/site/document/582"
+                        },
+                        "relevance": 38.755382811362274,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "587",
+                            "uri": "/selfcnil/api/configuration/site/document/587"
+                        },
+                        "relevance": 38.755382811362274,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1341",
+                            "uri": "/selfcnil/api/configuration/site/document/1341"
+                        },
+                        "relevance": 38.23049889039812,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1340",
+                            "uri": "/selfcnil/api/configuration/site/document/1340"
+                        },
+                        "relevance": 38.23049889039812,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "572",
+                            "uri": "/selfcnil/api/configuration/site/document/572"
+                        },
+                        "relevance": 38.23049889039812,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Que doivent faire les TPE-PME pour respecter le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.16666666666667,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "532",
+                            "uri": "/selfcnil/api/configuration/site/document/532"
+                        },
+                        "relevance": 69.72828575804628,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 25.034909426233128,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 24.909149719690046,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1327",
+                            "uri": "/selfcnil/api/configuration/site/document/1327"
+                        },
+                        "relevance": 24.76666666666667,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1327,
+        "epitca": [
+            {
+                "question": "Les associations doivent-elles respecter le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.17241379310344,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 94.97292029815684,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 94.97292029815684,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 94.97292029815684,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 94.34247699926877,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 85.7807730175116,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "582",
+                            "uri": "/selfcnil/api/configuration/site/document/582"
+                        },
+                        "relevance": 33.70891905073642,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "587",
+                            "uri": "/selfcnil/api/configuration/site/document/587"
+                        },
+                        "relevance": 33.70891905073642,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "858",
+                            "uri": "/selfcnil/api/configuration/site/document/858"
+                        },
+                        "relevance": 33.137063379804516,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1341",
+                            "uri": "/selfcnil/api/configuration/site/document/1341"
+                        },
+                        "relevance": 32.39047570481389,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Quelles sont les obligations RGPD des associations ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.14925373134328,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 88.14233702836464,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 88.14210453170138,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 88.14210453170138,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 88.14210453170138,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 88.14208128203506,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1260",
+                            "uri": "/selfcnil/api/configuration/site/document/1260"
+                        },
+                        "relevance": 67.10773495923004,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 65.79670209210262,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1257",
+                            "uri": "/selfcnil/api/configuration/site/document/1257"
+                        },
+                        "relevance": 56.84413420432388,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1397",
+                            "uri": "/selfcnil/api/configuration/site/document/1397"
+                        },
+                        "relevance": 55.01387417427674,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Que doivent faire les associations pour respecter le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "532",
+                            "uri": "/selfcnil/api/configuration/site/document/532"
+                        },
+                        "relevance": 95.125,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1327",
+                            "uri": "/selfcnil/api/configuration/site/document/1327"
+                        },
+                        "relevance": 47.09935811497354,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 24.94994344751146,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "277",
+                            "uri": "/selfcnil/api/configuration/site/document/277"
+                        },
+                        "relevance": 24.725019684569325,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 24.725019684569325,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 24.725019684569325,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1348,
+        "epitca": [
+            {
+                "question": "Quelles formalit\u00e9s pour les fichiers des administrateurs judiciaires ? ",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 95.35714285714286,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "547",
+                            "uri": "/selfcnil/api/configuration/site/document/547"
+                        },
+                        "relevance": 73.50077575399473,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 40.86615247719014,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 40.84897028992303,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 40.831789960993284,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 40.78196050291624,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "380",
+                            "uri": "/selfcnil/api/configuration/site/document/380"
+                        },
+                        "relevance": 40.77474457893201,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 40.764318386136644,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 40.76392162212435,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "414",
+                            "uri": "/selfcnil/api/configuration/site/document/414"
+                        },
+                        "relevance": 40.76031458930091,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Comment respecter le RGPD dans le cas de personnes plac\u00e9es sous l'autorit\u00e9 d'administrateurs ou mandataires judiciaires ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "238",
+                            "uri": "/selfcnil/api/configuration/site/document/238"
+                        },
+                        "relevance": 95.2433090024331,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 95.00347550982534,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.00251458078557,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 94.97798443583417,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 94.92849339521968,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "495",
+                            "uri": "/selfcnil/api/configuration/site/document/495"
+                        },
+                        "relevance": 94.81893161459978,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "246",
+                            "uri": "/selfcnil/api/configuration/site/document/246"
+                        },
+                        "relevance": 94.7359720341212,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 94.45816373875603,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "765",
+                            "uri": "/selfcnil/api/configuration/site/document/765"
+                        },
+                        "relevance": 94.45658444926221,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "106",
+                            "uri": "/selfcnil/api/configuration/site/document/106"
+                        },
+                        "relevance": 94.1654249210889,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Quelles modalit\u00e9s pour g\u00e9rer les fichiers des administrateurs et mandataires judiciaire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 95.22935779816514,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 85.52528267851355,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1248",
+                            "uri": "/selfcnil/api/configuration/site/document/1248"
+                        },
+                        "relevance": 85.49378853879638,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 85.03934580547244,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 84.99601105699072,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 84.88752291728859,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 84.83743030039504,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "554",
+                            "uri": "/selfcnil/api/configuration/site/document/554"
+                        },
+                        "relevance": 84.83563081931808,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 84.80499372476343,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "492",
+                            "uri": "/selfcnil/api/configuration/site/document/492"
+                        },
+                        "relevance": 84.80018897223081,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1350,
+        "epitca": [
+            {
+                "question": "Avec le RGPD, reste-t-il des d\u00e9clarations \u00e0 faire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1267",
+                            "uri": "/selfcnil/api/configuration/site/document/1267"
+                        },
+                        "relevance": 95.8,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1392",
+                            "uri": "/selfcnil/api/configuration/site/document/1392"
+                        },
+                        "relevance": 86.39589886134861,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 49.057143787565536,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 49.01037841347715,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 49.005629334216685,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 49.00420522128334,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 44.370037383449535,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 44.35444673321261,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 44.354435619261764,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 44.33884274623466,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Reste-t-il des formalit\u00e9s d\u00e9claratives  \u00e0 mettre en \u0153uvre depuis le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 95.37037037037037,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "250",
+                            "uri": "/selfcnil/api/configuration/site/document/250"
+                        },
+                        "relevance": 91.78354766580429,
+                        "matchingLocations": [
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 90.9035683240496,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "501",
+                            "uri": "/selfcnil/api/configuration/site/document/501"
+                        },
+                        "relevance": 90.5530076862814,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 90.22383409222911,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 90.2138854336077,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "407",
+                            "uri": "/selfcnil/api/configuration/site/document/407"
+                        },
+                        "relevance": 90.20393677498627,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1548",
+                            "uri": "/selfcnil/api/configuration/site/document/1548"
+                        },
+                        "relevance": 90.20393677498627,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "259",
+                            "uri": "/selfcnil/api/configuration/site/document/259"
+                        },
+                        "relevance": 90.19896244567556,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 90.19398811636485,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Que faut-il d\u00e9clarer \u00e0 la CNIL depuis le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 95.18181818181819,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "546",
+                            "uri": "/selfcnil/api/configuration/site/document/546"
+                        },
+                        "relevance": 91.0790901579764,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 88.17962407829292,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 87.99228248685894,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "717",
+                            "uri": "/selfcnil/api/configuration/site/document/717"
+                        },
+                        "relevance": 87.8720519492991,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "337",
+                            "uri": "/selfcnil/api/configuration/site/document/337"
+                        },
+                        "relevance": 68.20292092625864,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 67.65987172491612,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "781",
+                            "uri": "/selfcnil/api/configuration/site/document/781"
+                        },
+                        "relevance": 59.6766237463113,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "766",
+                            "uri": "/selfcnil/api/configuration/site/document/766"
+                        },
+                        "relevance": 49.447007200827,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1350",
+                            "uri": "/selfcnil/api/configuration/site/document/1350"
+                        },
+                        "relevance": 39.937319162251605,
+                        "matchingLocations": []
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1369,
+        "epitca": [
+            {
+                "question": "Que change le RGPD aux r\u00e8gles concernant les cookies ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 48.83047955918442,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1253",
+                            "uri": "/selfcnil/api/configuration/site/document/1253"
+                        },
+                        "relevance": 48.795134523790686,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "842",
+                            "uri": "/selfcnil/api/configuration/site/document/842"
+                        },
+                        "relevance": 46.11088480283714,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 46.11069104262174,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 46.11069104262174,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 25.254899345410877,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 25.24439009193424,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1348",
+                            "uri": "/selfcnil/api/configuration/site/document/1348"
+                        },
+                        "relevance": 25.24439009193424,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "541",
+                            "uri": "/selfcnil/api/configuration/site/document/541"
+                        },
+                        "relevance": 25.238255272250488,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "801",
+                            "uri": "/selfcnil/api/configuration/site/document/801"
+                        },
+                        "relevance": 25.235832280447525,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Cookies, qu'est-ce qui change avec le RGPD ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 25.130222742682314,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Le RGPD modifie-t-il la r\u00e9glementation sur les cookies ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 87.50713203634827,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1380",
+                            "uri": "/selfcnil/api/configuration/site/document/1380"
+                        },
+                        "relevance": 86.8148898056306,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "845",
+                            "uri": "/selfcnil/api/configuration/site/document/845"
+                        },
+                        "relevance": 85.48716476607062,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 85.40342259225679,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 85.24751841154051,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "112",
+                            "uri": "/selfcnil/api/configuration/site/document/112"
+                        },
+                        "relevance": 85.24384799658736,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "512",
+                            "uri": "/selfcnil/api/configuration/site/document/512"
+                        },
+                        "relevance": 85.23030579714265,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 85.08267018979915,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "162",
+                            "uri": "/selfcnil/api/configuration/site/document/162"
+                        },
+                        "relevance": 85.07780304190561,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "259",
+                            "uri": "/selfcnil/api/configuration/site/document/259"
+                        },
+                        "relevance": 85.07049774589643,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "text"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1395,
+        "epitca": [
+            {
+                "question": "Faut-il faire une analyse d'impact sur la vie priv\u00e9e lorsqu'on est m\u00e9decin ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "203",
+                            "uri": "/selfcnil/api/configuration/site/document/203"
+                        },
+                        "relevance": 95.187265917603,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "268",
+                            "uri": "/selfcnil/api/configuration/site/document/268"
+                        },
+                        "relevance": 92.06092039026916,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "210",
+                            "uri": "/selfcnil/api/configuration/site/document/210"
+                        },
+                        "relevance": 90.97229914165729,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "383",
+                            "uri": "/selfcnil/api/configuration/site/document/383"
+                        },
+                        "relevance": 90.89133060831658,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "864",
+                            "uri": "/selfcnil/api/configuration/site/document/864"
+                        },
+                        "relevance": 90.3907430976956,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "204",
+                            "uri": "/selfcnil/api/configuration/site/document/204"
+                        },
+                        "relevance": 90.29218908224011,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 90.26884989491033,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "533",
+                            "uri": "/selfcnil/api/configuration/site/document/533"
+                        },
+                        "relevance": 90.25611382434829,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "393",
+                            "uri": "/selfcnil/api/configuration/site/document/393"
+                        },
+                        "relevance": 90.10755154004576,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1349",
+                            "uri": "/selfcnil/api/configuration/site/document/1349"
+                        },
+                        "relevance": 89.941163574555,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Une AIPD est-elle n\u00e9cessaire pour l'exercice d'activit\u00e9s m\u00e9dicales ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1477",
+                            "uri": "/selfcnil/api/configuration/site/document/1477"
+                        },
+                        "relevance": 95.125,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 76.64312805464415,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "430",
+                            "uri": "/selfcnil/api/configuration/site/document/430"
+                        },
+                        "relevance": 76.62642093813133,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1342",
+                            "uri": "/selfcnil/api/configuration/site/document/1342"
+                        },
+                        "relevance": 55.364162324759334,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1393",
+                            "uri": "/selfcnil/api/configuration/site/document/1393"
+                        },
+                        "relevance": 55.19921516629908,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "853",
+                            "uri": "/selfcnil/api/configuration/site/document/853"
+                        },
+                        "relevance": 5.484485401687153,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1349",
+                            "uri": "/selfcnil/api/configuration/site/document/1349"
+                        },
+                        "relevance": 5.146035082357557,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1327",
+                            "uri": "/selfcnil/api/configuration/site/document/1327"
+                        },
+                        "relevance": 5.125,
+                        "matchingLocations": []
+                    }
+                ]
+            },
+            {
+                "question": "Les m\u00e9decins doivent-ils r\u00e9aliser une analyse d'impact ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "473",
+                            "uri": "/selfcnil/api/configuration/site/document/473"
+                        },
+                        "relevance": 95.3125,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "472",
+                            "uri": "/selfcnil/api/configuration/site/document/472"
+                        },
+                        "relevance": 95.30900157491212,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "474",
+                            "uri": "/selfcnil/api/configuration/site/document/474"
+                        },
+                        "relevance": 95.29668800288083,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "475",
+                            "uri": "/selfcnil/api/configuration/site/document/475"
+                        },
+                        "relevance": 95.29668800288083,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "749",
+                            "uri": "/selfcnil/api/configuration/site/document/749"
+                        },
+                        "relevance": 84.61735442846027,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "264",
+                            "uri": "/selfcnil/api/configuration/site/document/264"
+                        },
+                        "relevance": 84.61720506978219,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "496",
+                            "uri": "/selfcnil/api/configuration/site/document/496"
+                        },
+                        "relevance": 84.61720506978219,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "430",
+                            "uri": "/selfcnil/api/configuration/site/document/430"
+                        },
+                        "relevance": 84.61720506978219,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "85",
+                            "uri": "/selfcnil/api/configuration/site/document/85"
+                        },
+                        "relevance": 84.61720506978219,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1344",
+                            "uri": "/selfcnil/api/configuration/site/document/1344"
+                        },
+                        "relevance": 64.0059401985124,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    },
+    {
+        "expected": 1477,
+        "epitca": [
+            {
+                "question": "Comment mettre en \u0153uvre des mesures de contr\u00f4le d'acc\u00e8s biom\u00e9trique ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "1477",
+                            "uri": "/selfcnil/api/configuration/site/document/1477"
+                        },
+                        "relevance": 95.14285714285714,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 83.69233448037974,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "359",
+                            "uri": "/selfcnil/api/configuration/site/document/359"
+                        },
+                        "relevance": 45.321264994334555,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "821",
+                            "uri": "/selfcnil/api/configuration/site/document/821"
+                        },
+                        "relevance": 24.84694686774487,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "819",
+                            "uri": "/selfcnil/api/configuration/site/document/819"
+                        },
+                        "relevance": 24.77975042367521,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "529",
+                            "uri": "/selfcnil/api/configuration/site/document/529"
+                        },
+                        "relevance": 24.742868640677685,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "343",
+                            "uri": "/selfcnil/api/configuration/site/document/343"
+                        },
+                        "relevance": 24.742857142857144,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Peut-on mettre en \u0153uvre des traitement biom\u00e9trique au travail ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "494",
+                            "uri": "/selfcnil/api/configuration/site/document/494"
+                        },
+                        "relevance": 95.71428571428571,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1477",
+                            "uri": "/selfcnil/api/configuration/site/document/1477"
+                        },
+                        "relevance": 90.07616282691603,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1268",
+                            "uri": "/selfcnil/api/configuration/site/document/1268"
+                        },
+                        "relevance": 54.39749568892503,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 54.39747181534308,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 54.39735244743337,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 54.39728082668754,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "821",
+                            "uri": "/selfcnil/api/configuration/site/document/821"
+                        },
+                        "relevance": 44.9591824509311,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1350",
+                            "uri": "/selfcnil/api/configuration/site/document/1350"
+                        },
+                        "relevance": 38.133628862336785,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "1254",
+                            "uri": "/selfcnil/api/configuration/site/document/1254"
+                        },
+                        "relevance": 26.62920928420639,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 26.529825135695194,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "question": "Traitement de donn\u00e9es biom\u00e9trique au travail, comment faire ?",
+                "result": [
+                    {
+                        "document": {
+                            "id": "109",
+                            "uri": "/selfcnil/api/configuration/site/document/109"
+                        },
+                        "relevance": 95.32362459546925,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "281",
+                            "uri": "/selfcnil/api/configuration/site/document/281"
+                        },
+                        "relevance": 95.31960724580662,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "328",
+                            "uri": "/selfcnil/api/configuration/site/document/328"
+                        },
+                        "relevance": 95.23743002630985,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "106",
+                            "uri": "/selfcnil/api/configuration/site/document/106"
+                        },
+                        "relevance": 95.18390268048474,
+                        "matchingLocations": [
+                            {
+                                "type": "html"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "786",
+                            "uri": "/selfcnil/api/configuration/site/document/786"
+                        },
+                        "relevance": 94.55566636745667,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "821",
+                            "uri": "/selfcnil/api/configuration/site/document/821"
+                        },
+                        "relevance": 49.98014410635092,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1477",
+                            "uri": "/selfcnil/api/configuration/site/document/1477"
+                        },
+                        "relevance": 45.978396055385915,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "1538",
+                            "uri": "/selfcnil/api/configuration/site/document/1538"
+                        },
+                        "relevance": 39.832665268953136,
+                        "matchingLocations": []
+                    },
+                    {
+                        "document": {
+                            "id": "819",
+                            "uri": "/selfcnil/api/configuration/site/document/819"
+                        },
+                        "relevance": 37.92008098353121,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    },
+                    {
+                        "document": {
+                            "id": "345",
+                            "uri": "/selfcnil/api/configuration/site/document/345"
+                        },
+                        "relevance": 37.19068402089405,
+                        "matchingLocations": [
+                            {
+                                "type": "description"
+                            },
+                            {
+                                "type": "html"
+                            },
+                            {
+                                "type": "label"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argopt
+backoff
 construct
 cython
 farm-haystack==0.8.0

--- a/src/evaluation/config/retriever_eval_squad_config.py
+++ b/src/evaluation/config/retriever_eval_squad_config.py
@@ -1,10 +1,11 @@
 parameters = {
-    "k": [3],
-    "retriever_type": ['bm25'],
+    "k": [1, 3],
+    "retriever_type": ['epitca', 'bm25'],
     "google_retriever_website": ['service-public.fr'],
     "squad_dataset": [
         "./clients/cnil/knowledge_base/squad.json"
     ],  # data/evaluation-datasets/fquad_valid_with_impossible_fraction.json data/evaluation-datasets/testing_squad_format.json
+    "epitca_perf_file": ["./clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json"],
     "filter_level": [None],
     "boosting": [1],
     "preprocessing": [False],

--- a/src/evaluation/config/retriever_eval_squad_config.py
+++ b/src/evaluation/config/retriever_eval_squad_config.py
@@ -5,6 +5,8 @@ parameters = {
     "squad_dataset": [
         "./clients/cnil/knowledge_base/squad.json"
     ],  # data/evaluation-datasets/fquad_valid_with_impossible_fraction.json data/evaluation-datasets/testing_squad_format.json
+    # Path to the Epitca performance file or None. Needed when using the
+    # retriever_type 'epitca'.
     "epitca_perf_file": ["./clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json"],
     "filter_level": [None],
     "boosting": [1],

--- a/src/evaluation/retriever/retriever_eval_squad.py
+++ b/src/evaluation/retriever/retriever_eval_squad.py
@@ -2,6 +2,7 @@ import hashlib
 import socket
 from datetime import datetime
 from pathlib import Path
+from pprint import pprint
 
 from farm.utils import initialize_device_settings
 from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
@@ -201,6 +202,8 @@ def single_run(parameters):
             "experiment_id": experiment_id,
         }
     )
+
+    pprint(retriever_eval_results)
 
     return retriever_eval_results
 

--- a/src/evaluation/retriever/retriever_eval_squad.py
+++ b/src/evaluation/retriever/retriever_eval_squad.py
@@ -168,13 +168,25 @@ def single_run(parameters):
     if retriever_type in ["sbert", "dpr"]:
         document_store.update_embeddings(retriever, index=doc_index)
 
+    if epitca_perf_file:
+        expected_answers = epitca_retriever.load_perf_file_expected_answer(epitca_perf_file)
+        custom_evaluation_questions = [{"query": q, "gold_ids": [a]} for q,a in
+            expected_answers.items()]
+        get_doc_id = lambda doc: doc.meta["id"]
+    else:
+        custom_evaluation_questions = None
+        get_doc_id = lambda doc: doc.id
+
     retriever_eval_results = eval_retriever(
         document_store=document_store,
         pipeline=p,
         top_k=k,
         label_index=label_index,
         doc_index=doc_index,
+        question_label_dict_list=custom_evaluation_questions,
+        get_doc_id = get_doc_id,
     )
+
     # Retriever Recall is the proportion of questions for which the correct document containing the answer is
     # among the correct documents
     print("Retriever Recall:", retriever_eval_results["recall"])

--- a/src/evaluation/utils/epitca_retriever.py
+++ b/src/evaluation/utils/epitca_retriever.py
@@ -1,0 +1,110 @@
+import logging
+import json
+from random import randint, choice
+from pathlib import Path
+from typing import Optional, List
+
+from haystack import Document
+
+from haystack.retriever.base import BaseRetriever
+from haystack.document_store.base import BaseDocumentStore
+
+logger = logging.getLogger(__name__)
+
+
+class EpitcaRetriever(BaseRetriever):
+
+    def __init__(self,
+                 document_store: BaseDocumentStore,
+                 top_k: int = 10,
+                 epitca_perf_file: str = "clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json"):
+        """
+            The EpitcaRetriever is intended for simulating the CNIL search
+            engine Epitca. It retrieves the documents listed as answers to the
+            questions in `epitca_perf_file`.
+
+            :param document_store: The document store that is used for
+            retrieving documents. Each document should contain a field "id" that
+            corresponds to the ids appearing in epitca_perf_file.
+            :param top_k: How many documents to retrieve
+            :param epitca_perf_file: the path to the json file containing
+            Epitca's performance data. It gives a list of questions,  the
+            documents ids returned by Epitca as well as the document id for the
+            expected response.
+        """
+        self.document_store = document_store
+        self.top_k = top_k
+        self.epitca_perf_file = Path(epitca_perf_file)
+        self.epitca_perf_dict = load_perf_file(self.epitca_perf_file)
+
+    def retrieve(self, query: str, filters: dict = None, top_k: Optional[int] = None, index: str = None) -> List[
+        Document]:
+        """
+            Scan through documents in DocumentStore and return a small number documents
+            that are most relevant to the query.
+
+            :param query: The query
+            :param filters: A dictionary where the keys specify a metadata field and the value is a list of accepted values for that field
+            :param top_k: How many documents to return per query.
+            :param index: The name of the index in the DocumentStore from which to retrieve documents
+            :return: a list of Document retrieved
+        """
+
+        if top_k is None:
+            top_k = self.top_k
+        if not self.document_store:
+            logger.error(
+                "Cannot perform retrieve() since initialized with document_store=None")
+            return []
+        if index is None:
+            index = self.document_store.index
+
+        try:
+            result_doc_ids = self.epitca_perf_dict[query][:top_k]
+        except KeyError:
+            raise KeyError(f"Query '{query}' not found in Epticas performance data")
+
+        documents = self.document_store.query("*",
+            filters={"id": result_doc_ids})
+
+        return documents
+
+
+def load_perf_file(epitca_perf_file):
+    """
+    This loads the Epitca performance data.
+
+    :returns: a dictionary where the keys are the questions asked and values
+    """
+    data = {}
+    with open(epitca_perf_file, 'r') as f:
+        data = json.load(f)
+
+    epitca_perf_dict = {}
+
+    for expected_answer_group in data:
+        for question in expected_answer_group["epitca"]:
+            epitca_perf_dict[question["question"]] = \
+                    [result["document"]["id"] for result in question["result"]]
+
+    return epitca_perf_dict
+
+
+def load_perf_file_expected_answer(epitca_perf_file):
+    """
+    This loads the Epitca performance data.
+
+    :returns: a dictionary where the keys are the questions asked and values
+    """
+    data = {}
+    with open(epitca_perf_file, 'r') as f:
+        data = json.load(f)
+
+    expected = {}
+
+    for expected_answer_group in data:
+        for question in expected_answer_group["epitca"]:
+            expected[question["question"]] = \
+                    str(expected_answer_group["expected"])
+
+    return expected


### PR DESCRIPTION
## Reference to a related issue

Targetting #130

## Why is the change needed

To compare Piaf's retriever's performance to the CNIL's search engine Epitca.

## Description of the change

This PR adds the EpitcaRetriever that simulates the CNIL's search engine Epitca, along with epitca's performance data it uses.

The new retriever reads epitca's performance file which lists questions that were asked to epitca, the expected answers (document ids of the document that contains the answer), and epitca's answers for each question (a list of document ids). When asked one of the questions the new retriever fetches epitca's answers and returns the documents with the same ids from it's document_store.

## Experiment and results

I ran the retriever only pipeline experiment configured in the file `src/evaluation/config/retriever_eval_squad_config.py`. It runs the pipeline with k=1 and k=3, and with retrievers epitca and bm25, a total of 4 runs.

Each run feeds the document_store with the usual CNIL dataset `clients/cnil/knowledge_base/squad.json`. It then loads the questions from epitca's performance dataset `clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json` along with the expected answers. These are the questions and answers that are fed to the pipeline for evaluation rather than those in the usual CNIL dataset.

If my understanding is correct, we are interested the metric "recall" which is the proportion of times the pipeline result for a question contain the expected answer. I'm copying here the value of this metric for the 4 experiments, they are in favor of piaf:

```
               top 1    top 3
epitca         0.321    0.470
piaf (bm25)    0.505    0.690
```

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
@Rob192 