### PR TITLE
Fix working dir in non-regression-tests.

### DIFF
--- a/non-regression-tests/non-regression-tests
+++ b/non-regression-tests/non-regression-tests
@@ -16,6 +16,7 @@ fi
 mkdir -p $(dirname $LOCKFILE)
 echo $$ > $LOCKFILE
 
+cd $SRC_DIR/piaf-ml
 git fetch origin $TEST_BRANCH
 git reset --hard origin/$TEST_BRANCH
 


### PR DESCRIPTION
## Reference to a related issue

## Why is the change needed

The script `non-regression-tests` crashes when launched by cron because it doesn't run in piaf-ml directory

## Description of the change

cd to the piaf-ml source directory in the script

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
