### PR TITLE
Fix casting None to int.

### DIFF
--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -509,7 +509,7 @@ if __name__ == "__main__":
         parameters,
         parameter_tuning_options,
         elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME") or "localhost",
-        elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT")) or 9200)
+        elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT") or 9200))
 
     for (run_id, params, results) in runs:
         clean_log()


### PR DESCRIPTION
## Reference to a related issue

#142

## Why is the change needed

To prevent the cast to int from failing when the environment variable is not defined.

## Description of the change

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
