### PR TITLE
fix: group piaf-deployment must be able to write everywhere in the installation folder

### DIFF
--- a/deployment/roles/haystack/tasks/main.yml
+++ b/deployment/roles/haystack/tasks/main.yml
@@ -24,6 +24,7 @@
   file:
     path: "{{ client_installation_directory }}"
     group: "piaf-deployment"
+    mode: u=rwx,g=rwx,o=rx
     state: directory
     recurse: yes
 - name: "{{ client }} | copy custom_component.py"


### PR DESCRIPTION

## Reference to a related issue

## Why is the change needed
Because it does not work when someone else tries to install/reinstall a client

## Description of the change
Change the group rights to write everywhere in the haystack folder

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
