### PR TITLE
Refactor pipeline construction.

### DIFF
--- a/src/evaluation/config/retriever_eval_squad_config.py
+++ b/src/evaluation/config/retriever_eval_squad_config.py
@@ -1,13 +1,15 @@
 parameters = {
     "k": [1, 3],
-    "retriever_type": ['epitca', 'bm25'],
+    # "retriever_type": ["bm25", "sbert", "google", "epitca"],
+    "retriever_type": ["bm25"],
+    "retriever_model_version": ["1a01b38498875d45f69b2a6721bf6fe87425da39"],
     "google_retriever_website": ['service-public.fr'],
-    "squad_dataset": [
-        "./clients/cnil/knowledge_base/squad.json"
-    ],  # data/evaluation-datasets/fquad_valid_with_impossible_fraction.json data/evaluation-datasets/testing_squad_format.json
+    # "squad_dataset": ["./clients/cnil/knowledge_base/squad.json"],
+    "squad_dataset": ["./test/samples/squad/tiny.json"],
     # Path to the Epitca performance file or None. Needed when using the
     # retriever_type 'epitca'.
-    "epitca_perf_file": ["./clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json"],
+    #"epitca_perf_file": ["./clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json"],
+    "epitca_perf_file": [None],
     "filter_level": [None],
     "boosting": [1],
     "preprocessing": [False],

--- a/src/evaluation/retriever/retriever_eval_squad.py
+++ b/src/evaluation/retriever/retriever_eval_squad.py
@@ -1,14 +1,19 @@
+import os
 import hashlib
 import socket
+from dotenv import load_dotenv
 from datetime import datetime
 from pathlib import Path
 from pprint import pprint
+
+from deployment.roles.haystack.files.custom_component import \
+        TitleEmbeddingRetriever
 
 from farm.utils import initialize_device_settings
 from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
 from haystack.pipeline import Pipeline
 from haystack.preprocessor.preprocessor import PreProcessor
-from haystack.retriever.dense import EmbeddingRetriever
+from haystack.retriever.dense import EmbeddingRetriever, DensePassageRetriever
 from haystack.retriever.sparse import ElasticsearchRetriever
 from sklearn.model_selection import ParameterGrid
 from tqdm import tqdm
@@ -18,13 +23,20 @@ from src.evaluation.config.retriever_eval_squad_config import parameters
 from src.evaluation.utils.elasticsearch_management import (delete_indices,
                                                            launch_ES,
                                                            prepare_mapping)
-from src.evaluation.utils.google_retriever import GoogleRetriever
-from src.evaluation.utils.epitca_retriever import EpitcaRetriever
 from src.evaluation.utils import epitca_retriever
 from src.evaluation.utils.utils_eval import eval_retriever, save_results
 
+import src.evaluation.utils.pipelines as pipelines
 
-def single_run(parameters):
+device, n_gpu = initialize_device_settings(use_cuda=True)
+GPU_AVAILABLE = 1 if device.type == "cuda" else 0
+
+if GPU_AVAILABLE:
+    gpu_id = torch.cuda.current_device()
+else:
+    gpu_id = -1
+
+def single_run(parameters, elasticsearch_hostname, elasticsearch_port):
     """
     Runs a grid search config 
 
@@ -35,139 +47,41 @@ def single_run(parameters):
     evaluation_data = Path(parameters["squad_dataset"])
     retriever_type = parameters["retriever_type"]
     k = parameters["k"]
-    title_boosting_factor = parameters["boosting"]
+    epitca_perf_file = parameters["epitca_perf_file"]
+    experiment_id = hashlib.md5(str(parameters).encode("utf-8")).hexdigest()[:4]
+
+    # deleted indice for elastic search to make sure mappings are properly passed
+    delete_indices(index="document_elasticsearch")
+    delete_indices(index="label_elasticsearch")
+
+    p = pipelines.retriever(parameters, elasticsearch_hostname, 
+            elasticsearch_port,
+            gpu_id = gpu_id)
+
+    document_store = p.get_node("Retriever").document_store
+
     preprocessing = parameters["preprocessing"]
     split_by = parameters["split_by"]
     split_length = parameters["split_length"]
-    split_respect_sentence_boundary = parameters["split_respect_sentence_boundary"]
-    experiment_id = hashlib.md5(str(parameters).encode("utf-8")).hexdigest()[:4]
-    google_retriever_website = parameters["google_retriever_website"]
-    epitca_perf_file = parameters["epitca_perf_file"]
-    # Prepare framework
-
-    p = Pipeline()
-
-    # indexes for the elastic search
-    doc_index = "document_xp"
-    label_index = "label_xp"
-
-    # deleted indice for elastic search to make sure mappings are properly passed
-    delete_indices(index=doc_index)
-    delete_indices(index=label_index)
-
-    prepare_mapping(
-        mapping=SQUAD_MAPPING,
-        title_boosting_factor=title_boosting_factor,
-        embedding_dimension=768,
-    )
-
     if preprocessing:
-        preprocessor = PreProcessor(
-            clean_empty_lines=False,
-            clean_whitespace=False,
-            clean_header_footer=False,
-            split_by=split_by,
-            split_length=split_length,
-            split_overlap=0,  # this must be set to 0 at the data of writting this: 22 01 2021
-            split_respect_sentence_boundary=False,  # the support for this will soon be removed : 29 01 2021
-        )
+        preprocessor = pipelines.components.preprocessors.preprocessor(split_by, split_length)
     else:
         preprocessor = None
-
-    if retriever_type == "bm25":
-
-        document_store = ElasticsearchDocumentStore(
-            host="localhost",
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            scheme="",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = ElasticsearchRetriever(document_store=document_store)
-        p.add_node(component=retriever, name="ESRetriever", inputs=["Query"])
-
-    elif retriever_type == "sbert":
-        document_store = ElasticsearchDocumentStore(
-            host="localhost",
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = EmbeddingRetriever(
-            document_store=document_store,
-            embedding_model="distiluse-base-multilingual-cased",
-            use_gpu=GPU_AVAILABLE,
-            model_format="sentence_transformers",
-            pooling_strategy="reduce_max",
-            emb_extraction_layer=-1,
-        )
-        p.add_node(component=retriever, name="SBertRetriever", inputs=["Query"])
-
-    elif retriever_type == "google":
-        document_store = ElasticsearchDocumentStore(
-            host="localhost",
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            scheme="",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = GoogleRetriever(document_store=document_store, website=google_retriever_website)
-        p.add_node(component=retriever, name="GoogleRetriever", inputs=["Query"])
-
-    elif retriever_type == "epitca":
-        document_store = ElasticsearchDocumentStore(
-            host="localhost",
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            scheme="",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = EpitcaRetriever(document_store=document_store)
-        p.add_node(component=retriever, name="EpitcaRetriever", inputs=["Query"])
-
-    else:
-        raise Exception(
-            f"You chose {retriever_type}. Choose one from bm25, sbert, google or dpr"
-        )
 
     # Add evaluation data to Elasticsearch document store
     document_store.add_eval_data(
         evaluation_data.as_posix(),
-        doc_index=doc_index,
-        label_index=label_index,
+        doc_index="document_elasticsearch",
+        label_index="label_elasticsearch",
         preprocessor=preprocessor,
     )
 
-    if retriever_type in ["sbert", "dpr"]:
-        document_store.update_embeddings(retriever, index=doc_index)
+    retriever = p.get_node("Retriever")
+
+    if type(retriever) in [DensePassageRetriever, TitleEmbeddingRetriever, 
+            EmbeddingRetriever]:
+        document_store.update_embeddings(retriever,
+                index="document_elasticsearch")
 
     if epitca_perf_file:
         expected_answers = epitca_retriever.load_perf_file_expected_answer(epitca_perf_file)
@@ -182,8 +96,8 @@ def single_run(parameters):
         document_store=document_store,
         pipeline=p,
         top_k=k,
-        label_index=label_index,
-        doc_index=doc_index,
+        label_index="label_elasticsearch",
+        doc_index="document_elasticsearch",
         question_label_dict_list=custom_evaluation_questions,
         get_doc_id = get_doc_id,
     )
@@ -209,16 +123,18 @@ def single_run(parameters):
 
 
 if __name__ == "__main__":
+    load_dotenv()
+    elasticsearch_hostname = os.getenv("ELASTICSEARCH_HOSTNAME") or "localhost"
+    elasticsearch_port = int(os.getenv("ELASTICSEARCH_PORT")) or 9200
+
     result_file_path = Path("./output/results.csv")
     parameters_grid = list(ParameterGrid(param_grid=parameters))
-
-    device, n_gpu = initialize_device_settings(use_cuda=True)
-    GPU_AVAILABLE = 1 if device == "gpu" else 0
 
     all_results = []
     launch_ES()
     for param in tqdm(parameters_grid, desc="GridSearch"):
         # START XP
-        run_results = single_run(param)
+        run_results = single_run(param, elasticsearch_hostname,
+                elasticsearch_port)
         # all_results.append(run_results)
         save_results(result_file_path=result_file_path, results_list=run_results)

--- a/src/evaluation/retriever/title_qa_pipeline_eval.py
+++ b/src/evaluation/retriever/title_qa_pipeline_eval.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from src.evaluation.config.elasticsearch_mappings import SQUAD_MAPPING
 from src.evaluation.config.title_qa_pipeline_config import parameters
-from src.evaluation.utils.custom_pipelines import TitleQAPipeline
+from src.evaluation.utils.pipelines.custom_pipelines import TitleQAPipeline
 from src.evaluation.utils.elasticsearch_management import (delete_indices,
                                                            launch_ES,
                                                            prepare_mapping)

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -5,15 +5,15 @@ from pathlib import Path
 
 import torch
 
+from deployment.roles.haystack.files.custom_component import \
+        TitleEmbeddingRetriever
+
+from haystack.retriever.dense import EmbeddingRetriever, DensePassageRetriever
+
 from src.evaluation.utils.logging_management import clean_log
 import mlflow
 from dotenv import load_dotenv
 from farm.utils import BaseMLLogger, initialize_device_settings
-from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
-from haystack.preprocessor.preprocessor import PreProcessor
-from haystack.reader.transformers import TransformersReader
-from haystack.retriever.dense import EmbeddingRetriever, DensePassageRetriever
-from haystack.retriever.sparse import ElasticsearchRetriever
 from mlflow.tracking import MlflowClient
 import pprint
 from sklearn.model_selection import ParameterGrid
@@ -23,17 +23,16 @@ import sys
 from tqdm import tqdm
 
 from src.evaluation.utils.utils_eval import save_results, \
-    full_eval_retriever_reader, PiafEvalRetriever, PiafEvalReader
-from src.evaluation.utils.custom_pipelines import \
-    RetrieverReaderEvaluationPipeline, TitleBM25QAEvaluationPipeline, HottestReaderPipeline
+    full_eval_retriever_reader
 from src.evaluation.config.elasticsearch_mappings import SQUAD_MAPPING
 from src.evaluation.utils.elasticsearch_management import delete_indices, \
     launch_ES, prepare_mapping
 from src.evaluation.utils.mlflow_management import add_extra_params, \
     create_run_ids, get_list_past_run, prepare_mlflow_server, mlflow_log_run
-from src.evaluation.utils.TitleEmbeddingRetriever import TitleEmbeddingRetriever
 from src.evaluation.utils.utils_optimizer import LoggingCallback, \
     create_dimensions_from_parameters
+
+import src.evaluation.utils.pipelines as pipelines
 
 BaseMLLogger.disable_logging = True
 load_dotenv()
@@ -48,275 +47,64 @@ else:
 
 
 def single_run(
+        parameters,
         idx=None,
-        gpu_id=-1,
-        elasticsearch_hostname="localhost",
-        elasticsearch_port=9200,
-        **kwargs):
+        gpu_id = -1,
+        elasticsearch_hostname = "localhost",
+        elasticsearch_port = 9200,
+        ):
     """
     Perform one run of the pipeline under testing with the parameters given in the config file. The results are
     saved in the mlflow instance.
     """
 
-    # Gather parameters
-    evaluation_data = Path(kwargs["squad_dataset"])
-    retriever_type = kwargs["retriever_type"]
-    k_retriever = kwargs["k_retriever"]
-    k_title_retriever = kwargs["k_title_retriever"]
-    k_reader_per_candidate = kwargs["k_reader_per_candidate"]
-    k_reader_total = kwargs["k_reader_total"]
-    threshold_score = kwargs["threshold_score"]
-    preprocessing = kwargs["preprocessing"]
-    reader_model_version = kwargs["reader_model_version"]
-    retriever_model_version = kwargs["retriever_model_version"]
-    dpr_model_version = kwargs["dpr_model_version"]
-    split_by = kwargs["split_by"]
-    split_length = int(kwargs["split_length"])  # this is intended to convert numpy.int64 to int
-    title_boosting_factor = kwargs["boosting"]
+    evaluation_data = Path(parameters["squad_dataset"])
 
-    # indexes for the elastic search
-    doc_index = "document_xp"
-    label_index = "label_xp"
+    p = pipelines.retriever_reader(parameters, gpu_id, elasticsearch_hostname,
+            elasticsearch_port)
 
-    # deleted indice for elastic search to make sure mappings are properly passed
-    delete_indices(elasticsearch_hostname, elasticsearch_port, index=doc_index)
-    delete_indices(elasticsearch_hostname, elasticsearch_port, index=label_index)
+    # Get all the retrievers used in the pipelines.
+    retrievers = [p.get_node(name)
+            for name in ["Retriever", "Retriever_bm25", "Retriever_title"] 
+            if p.get_node(name)]
 
-    prepare_mapping(
-        mapping=SQUAD_MAPPING,
-        title_boosting_factor=title_boosting_factor,
-        embedding_dimension=768,
-    )
+    # When there are multiple retrievers, the same document_store is attached
+    # to all of them. Take the first one.
+    document_store = retrievers[0].document_store
 
+    preprocessing = parameters["preprocessing"]
+    split_by = parameters["split_by"]
+    split_length = int(parameters["split_length"])  # this is intended to convert numpy.int64 to int
     if preprocessing:
-        preprocessor = PreProcessor(
-            clean_empty_lines=False,
-            clean_whitespace=False,
-            clean_header_footer=False,
-            split_by=split_by,
-            split_length=split_length,
-            split_overlap=0,  # this must be set to 0 at the date of writting this: 22 01 2021
-            split_respect_sentence_boundary=False,  # the support for this will soon be removed : 29 01 2021
-        )
+        preprocessor = pipelines.components.preprocessors.preprocessor(split_by, split_length)
     else:
         preprocessor = None
 
-    reader = TransformersReader(
-        model_name_or_path="etalab-ia/camembert-base-squadFR-fquad-piaf",
-        tokenizer="etalab-ia/camembert-base-squadFR-fquad-piaf",
-        model_version=reader_model_version,
-        use_gpu=gpu_id,
-        top_k_per_candidate=k_reader_per_candidate,
-    )
-
-    eval_retriever = PiafEvalRetriever()
-    eval_reader = PiafEvalReader()
-
-    if retriever_type == "bm25":
-        document_store = ElasticsearchDocumentStore(
-            host=elasticsearch_hostname,
-            port=elasticsearch_port,
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            scheme="",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = ElasticsearchRetriever(document_store=document_store)
-        p = RetrieverReaderEvaluationPipeline(
-            reader=reader,
-            retriever=retriever,
-            eval_retriever=eval_retriever,
-            eval_reader=eval_reader
-        )
-
-    elif retriever_type == "sbert":
-        document_store = ElasticsearchDocumentStore(
-            host=elasticsearch_hostname,
-            port=elasticsearch_port,
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = EmbeddingRetriever(
-            document_store=document_store,
-            embedding_model="distilbert-base-multilingual-cased",
-            model_version=retriever_model_version,
-            use_gpu=GPU_AVAILABLE,
-            model_format="transformers",
-            pooling_strategy="reduce_max",
-            emb_extraction_layer=-1,
-        )
-        p = RetrieverReaderEvaluationPipeline(
-            reader=reader,
-            retriever=retriever,
-            eval_retriever=eval_retriever,
-            eval_reader=eval_reader
-        )
-
-    elif retriever_type == "dpr":
-        document_store = ElasticsearchDocumentStore(
-            host=elasticsearch_hostname,
-            port=elasticsearch_port,
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity='dot_product',
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = DensePassageRetriever(
-            document_store=document_store,
-            query_embedding_model="etalab-ia/dpr-question_encoder-fr_qa-camembert",
-            passage_embedding_model="etalab-ia/dpr-ctx_encoder-fr_qa-camembert",
-            model_version=dpr_model_version,
-            infer_tokenizer_classes=True,
-            use_gpu=GPU_AVAILABLE,
-        )
-        p = RetrieverReaderEvaluationPipeline(
-            reader=reader,
-            retriever=retriever,
-            eval_retriever=eval_retriever,
-            eval_reader=eval_reader
-        )
-
-    elif retriever_type == "title_bm25":
-        document_store = ElasticsearchDocumentStore(
-            host=elasticsearch_hostname,
-            port=elasticsearch_port,
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = TitleEmbeddingRetriever(
-            document_store=document_store,
-            embedding_model="distilbert-base-multilingual-cased",
-            model_version=retriever_model_version,
-            use_gpu=GPU_AVAILABLE,
-            model_format="transformers",
-            pooling_strategy="reduce_max",
-            emb_extraction_layer=-1,
-        )
-        retriever_bm25 = ElasticsearchRetriever(document_store=document_store)
-        p = TitleBM25QAEvaluationPipeline(reader=reader,
-                                          retriever_title=retriever,
-                                          retriever_bm25=retriever_bm25,
-                                          k_title_retriever=k_title_retriever,
-                                          k_bm25_retriever=k_retriever,
-                                          eval_retriever=eval_retriever,
-                                          eval_reader=eval_reader)
-
-        # used to make sure the p.run method returns enough candidates
-        k_retriever = max(k_retriever, k_title_retriever)
-
-    elif retriever_type == "title":
-        document_store = ElasticsearchDocumentStore(
-            host=elasticsearch_hostname,
-            port=elasticsearch_port,
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = TitleEmbeddingRetriever(
-            document_store=document_store,
-            embedding_model="distilbert-base-multilingual-cased",
-            model_version=retriever_model_version,
-            use_gpu=GPU_AVAILABLE,
-            model_format="transformers",
-            pooling_strategy="reduce_max",
-            emb_extraction_layer=-1,
-        )
-        p = RetrieverReaderEvaluationPipeline(
-            reader=reader,
-            retriever=retriever,
-            eval_retriever=eval_retriever,
-            eval_reader=eval_reader
-        )
-
-    elif retriever_type == "hot_reader":
-        document_store = ElasticsearchDocumentStore(
-            host="localhost",
-            username="",
-            password="",
-            index=doc_index,
-            search_fields=["name", "text"],
-            create_index=False,
-            embedding_field="emb",
-            embedding_dim=768,
-            excluded_meta_data=["emb"],
-            similarity="cosine",
-            custom_mapping=SQUAD_MAPPING,
-        )
-        retriever = TitleEmbeddingRetriever(
-            document_store=document_store,
-            embedding_model="distilbert-base-multilingual-cased",
-            model_version=retriever_model_version,
-            use_gpu=GPU_AVAILABLE,
-            model_format="transformers",
-            pooling_strategy="reduce_max",
-            emb_extraction_layer=-1,
-        )
-        retriever_bm25 = ElasticsearchRetriever(document_store=document_store)
-        p = HottestReaderPipeline(
-            reader=reader,
-            retriever_title=retriever,
-            retriever_bm25=retriever_bm25,
-            k_title_retriever=k_title_retriever,
-            k_bm25_retriever=k_retriever,
-            threshold_score=threshold_score,
-        )
-
-        # used to make sure the p.run method returns enough candidates
-        k_retriever = max(k_retriever, k_title_retriever)
-
-
-    else:
-        logging.error(
-            f"You chose {retriever_type}. Choose one from bm25, sbert, dpr, title_bm25 or title."
-        )
-        raise Exception(f"Wrong retriever type for {retriever_type}.")
+    # deleted indice for elastic search to make sure mappings are properly passed
+    delete_indices(elasticsearch_hostname, elasticsearch_port, index="document_elasticsearch")
+    delete_indices(elasticsearch_hostname, elasticsearch_port, index="label_elasticsearch")
 
     # Add evaluation data to Elasticsearch document store
     document_store.add_eval_data(
         evaluation_data.as_posix(),
-        doc_index=doc_index,
-        label_index=label_index,
+        doc_index="document_elasticsearch",
+        label_index="label_elasticsearch",
         preprocessor=preprocessor,
     )
 
-    if retriever_type in ["sbert", "dpr", "title_bm25", "title", "hot_reader"]:
-        document_store.update_embeddings(retriever, index=doc_index)
+    for retriever in retrievers:
+        if type(retriever) in [DensePassageRetriever, TitleEmbeddingRetriever, 
+                EmbeddingRetriever]:
+            document_store.update_embeddings(retriever, index="document_elasticsearch")
+
+    if parameters["retriever_type"] in ["title_bm25", "hot_reader"]:
+        # used to make sure the p.run method returns enough candidates
+        k_retriever = max(parameters["k_retriever"], parameters["k_title_retriever"])
+
+    else:
+        k_retriever = parameters["k_retriever"]
+
+    k_reader_total = parameters["k_reader_total"]
 
     retriever_reader_eval_results = {}
     try:
@@ -325,13 +113,15 @@ def single_run(
                                    pipeline=p,
                                    k_retriever=k_retriever,
                                    k_reader_total=k_reader_total,
-                                   label_index=label_index)
+                                   label_index="label_elasticsearch")
+
+        eval_retriever = p.get_node("EvalRetriever")
+        eval_reader = p.get_node("EvalReader")
 
         retriever_reader_eval_results.update(eval_retriever.get_metrics())
         retriever_reader_eval_results.update(eval_reader.get_metrics())
 
         end = time.time()
-
 
         logging.info(f"Retriever Recall: {retriever_reader_eval_results['recall']}")
         logging.info(f"Retriever Mean Avg Precision: {retriever_reader_eval_results['map']}")
@@ -341,12 +131,12 @@ def single_run(
 
         # Log time per label in metrics
         time_per_label = (end - start) / document_store.get_label_count(
-            index=label_index
+            index="label_elasticsearch"
         )
         retriever_reader_eval_results.update({"time_per_label": time_per_label})
 
     except Exception as e:
-        logging.error(f"Could not run this config: {kwargs}. Error {e}.")
+        logging.error(f"Could not run this config: {parameters}. Error {e}.")
 
     return retriever_reader_eval_results
 
@@ -367,12 +157,12 @@ def optimize(parameters, n_calls, result_file_path, gpu_id=-1,
     results = []
 
     @use_named_args(dimensions=dimensions)
-    def single_run_optimization(**kwargs):
-        result = single_run(gpu_id=gpu_id,
-                            elasticsearch_hostname=elasticsearch_hostname,
-                            elasticsearch_port=elasticsearch_port, **kwargs)
+    def single_run_optimization(params):
+        result = single_run(params, gpu_id = gpu_id,
+                            elasticsearch_hostname = elasticsearch_hostname, 
+                            elasticsearch_port = elasticsearch_port)
 
-        results.append((None, kwargs, result))
+        results.append((None, parameters, result))
 
         return 1 - result["reader_topk_accuracy_has_answer"]
 
@@ -420,9 +210,9 @@ def grid_search(parameters, mlflow_client, experiment_name, use_cache=False,
 
         else:  # run notalready done or USE_CACHE set to False or not set
             logging.info(f"Doing run with config : {param}")
-            run_results = single_run(idx=idx, gpu_id=gpu_id,
-                                     elasticsearch_hostname=elasticsearch_hostname,
-                                     elasticsearch_port=elasticsearch_port, **param)
+            run_results = single_run(param, gpu_id = gpu_id,
+                                     elasticsearch_hostname = elasticsearch_hostname,
+                                     elasticsearch_port = elasticsearch_port)
 
             # For debugging purpose, we keep a copy of the results in a csv form
             save_results(result_file_path=result_file_path,

--- a/src/evaluation/utils/pipelines/__init__.py
+++ b/src/evaluation/utils/pipelines/__init__.py
@@ -1,0 +1,139 @@
+"""
+This root module contains functions that build pipelines given a pipeline
+parameter dictionnary and a few other arguments. They are responsible for
+calling the right pipeline constructor function from the submodule
+`custom_pipelines` from the values in the parameter dict.
+
+There are two submodules: `custom_pipelines` and `components`.
+
+The `custom_pipelines` submodule contains functions that build pipelines.
+
+The `components` submodule contains functions that create the custom
+components used in the pipelines defined in the `custom_pipelines` submodule.
+"""
+
+from pathlib import Path
+from haystack.pipeline import Pipeline
+
+import src.evaluation.utils.pipelines.custom_pipelines as custom_pipelines
+
+def retriever(
+        parameters,
+        elasticsearch_hostname,
+        elasticsearch_port,
+        gpu_id = -1):
+
+    retriever_type = parameters["retriever_type"]
+
+    if retriever_type == "bm25":
+        return custom_pipelines.retriever_bm25(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"])
+
+    elif retriever_type == "sbert":
+        return custom_pipelines.retriever_sbert(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            retriever_model_version = parameters["retriever_model_version"],
+            gpu_available = gpu_id >= 0)
+
+    elif retriever_type == "google":
+        return custom_pipelines.retriever_google(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            google_retriever_website = parameters["google_retriever_website"])
+
+    elif retriever_type == "epitca":
+        return custom_pipelines.retriever_epitca(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"])
+
+    else:
+        raise Exception(
+            f"You chose {retriever_type}. Choose one from bm25, sbert, google or dpr"
+        )
+
+
+def retriever_reader(
+        parameters,
+        gpu_id = -1,
+        elasticsearch_hostname = "localhost",
+        elasticsearch_port = 9200,
+        ):
+
+    # Gather parameters
+    retriever_type = parameters["retriever_type"]
+
+    if retriever_type == "bm25":
+        return custom_pipelines.retriever_reader_bm25(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            reader_model_version = parameters["reader_model_version"],
+            gpu_id = gpu_id,
+            k_reader_per_candidate = parameters["k_reader_per_candidate"])
+
+    elif retriever_type == "sbert":
+        return custom_pipelines.retriever_reader_sbert(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            retriever_model_version = parameters["retriever_model_version"],
+            reader_model_version = parameters["reader_model_version"],
+            gpu_id = gpu_id,
+            k_reader_per_candidate = parameters["k_reader_per_candidate"])
+
+    elif retriever_type == "dpr":
+        return custom_pipelines.retriever_reader_dpr(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            dpr_model_version = parameters["dpr_model_version"],
+            reader_model_version = parameters["reader_model_version"],
+            gpu_id = gpu_id,
+            k_reader_per_candidate = parameters["k_reader_per_candidate"])
+
+    elif retriever_type == "title_bm25":
+        return custom_pipelines.retriever_reader_title_bm25(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            retriever_model_version = parameters["retriever_model_version"],
+            reader_model_version = parameters["reader_model_version"],
+            gpu_id = gpu_id,
+            k_reader_per_candidate = parameters["k_reader_per_candidate"],
+            k_title_retriever = parameters["k_title_retriever"],
+            k_bm25_retriever = parameters["k_retriever"])
+
+    elif retriever_type == "title":
+        return custom_pipelines.retriever_reader_title(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            retriever_model_version = parameters["retriever_model_version"],
+            reader_model_version = parameters["reader_model_version"],
+            gpu_id = gpu_id,
+            k_reader_per_candidate = parameters["k_reader_per_candidate"])
+
+    elif retriever_type == "hot_reader":
+        return custom_pipelines.hottest_reader_pipeline(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            title_boosting_factor = parameters["boosting"],
+            retriever_model_version = parameters["retriever_model_version"],
+            reader_model_version = parameters["reader_model_version"],
+            gpu_id = gpu_id,
+            k_reader_per_candidate = parameters["k_reader_per_candidate"],
+            k_title_retriever = parameters["k_title_retriever"],
+            k_bm25_retriever = parameters["k_retriever"],
+            threshold_score = parameters["threshold_score"])
+
+    else:
+        logging.error(
+            f"You chose {retriever_type}. Choose one from bm25, sbert, dpr, title_bm25 or title."
+        )
+        raise Exception(f"Wrong retriever type for {retriever_type}.")

--- a/src/evaluation/utils/pipelines/components/document_stores.py
+++ b/src/evaluation/utils/pipelines/components/document_stores.py
@@ -1,0 +1,82 @@
+from haystack.document_store.elasticsearch import ElasticsearchDocumentStore
+
+def elasticsearch(elasticsearch_hostname, elasticsearch_port,
+        similarity, embedding_dim, title_boosting_factor):
+
+    return ElasticsearchDocumentStore(
+            host=elasticsearch_hostname,
+            port=elasticsearch_port,
+            username="",
+            password="",
+            index="document_elasticsearch",
+            search_fields=["name", "text"],
+            create_index=False,
+            embedding_field="emb",
+            scheme="",
+            embedding_dim=embedding_dim,
+            excluded_meta_data=["emb"],
+            similarity=similarity,
+            custom_mapping=squad_mapping(embedding_dim, title_boosting_factor),
+        )
+
+def squad_mapping(embedding_dim, title_boosting_factor):
+    return {
+        "mappings": {
+            "properties": {
+                "name": {"type": "text", "boost": title_boosting_factor},
+                "text": {"type": "text"},
+                "emb": {"type": "dense_vector", "dims": embedding_dim},
+            },
+            "dynamic_templates": [
+                {
+                    "strings": {
+                        "path_match": "*",
+                        "match_mapping_type": "string",
+                        "mapping": {"type": "keyword"},
+                    }
+                }
+            ],
+        },
+        "settings": analyzer_default(),
+    }
+
+def analyzer_default():
+    return {
+        "analysis": {
+            "filter": {
+                "french_elision": {
+                    "type": "elision",
+                    "articles_case": True,
+                    "articles": [
+                        "l",
+                        "m",
+                        "t",
+                        "qu",
+                        "n",
+                        "s",
+                        "j",
+                        "d",
+                        "c",
+                        "jusqu",
+                        "quoiqu",
+                        "lorsqu",
+                        "puisqu",
+                    ],
+                },
+                "french_stop": {"type": "stop", "stopwords": "_french_"},
+                "french_stemmer": {"type": "stemmer", "language": "light_french"},
+            },
+            "analyzer": {
+                "default": {
+                    "tokenizer": "standard",
+                    "filter": [
+                        "french_elision",
+                        "lowercase",
+                        "french_stop",
+                        "french_stemmer",
+                    ],
+                }
+            },
+        }
+    }
+

--- a/src/evaluation/utils/pipelines/components/evals.py
+++ b/src/evaluation/utils/pipelines/components/evals.py
@@ -1,0 +1,7 @@
+from src.evaluation.utils.utils_eval import PiafEvalRetriever,PiafEvalReader
+
+def piaf_eval_retriever():
+    return PiafEvalRetriever()
+
+def piaf_eval_reader():
+    return PiafEvalReader()

--- a/src/evaluation/utils/pipelines/components/preprocessors.py
+++ b/src/evaluation/utils/pipelines/components/preprocessors.py
@@ -1,0 +1,13 @@
+from haystack.preprocessor.preprocessor import PreProcessor
+
+def preprocessor(split_by, split_length):
+    return PreProcessor(
+            clean_empty_lines=False,
+            clean_whitespace=False,
+            clean_header_footer=False,
+            split_by=split_by,
+            split_length=split_length,
+            split_overlap=0,  # this must be set to 0 at the date of writting this: 22 01 2021
+            split_respect_sentence_boundary=False,  # the support for this will soon be removed : 29 01 2021
+        )
+

--- a/src/evaluation/utils/pipelines/components/readers.py
+++ b/src/evaluation/utils/pipelines/components/readers.py
@@ -1,0 +1,11 @@
+from haystack.reader.transformers import TransformersReader
+
+def transformers_reader(reader_model_version, gpu_id, k_reader_per_candidate):
+    return TransformersReader(
+        model_name_or_path="etalab-ia/camembert-base-squadFR-fquad-piaf",
+        tokenizer="etalab-ia/camembert-base-squadFR-fquad-piaf",
+        model_version=reader_model_version,
+        use_gpu=gpu_id,
+        top_k_per_candidate=k_reader_per_candidate,
+    )
+

--- a/src/evaluation/utils/pipelines/components/retrievers.py
+++ b/src/evaluation/utils/pipelines/components/retrievers.py
@@ -1,0 +1,61 @@
+from deployment.roles.haystack.files.custom_component import \
+       TitleEmbeddingRetriever
+from haystack.retriever.dense import EmbeddingRetriever, DensePassageRetriever
+from haystack.retriever.sparse import ElasticsearchRetriever
+from src.evaluation.utils.google_retriever import GoogleRetriever
+from src.evaluation.utils.epitca_retriever import EpitcaRetriever
+
+def bm25(document_store):
+    return ElasticsearchRetriever(document_store=document_store)
+
+def epitca(document_store):
+    return EpitcaRetriever(document_store=document_store)
+
+def google(document_store, google_retriever_website):
+    return GoogleRetriever(document_store=document_store,
+            website=google_retriever_website)
+
+def sbert(document_store, retriever_model_version, gpu_available):
+    return EmbeddingRetriever(
+            document_store=document_store,
+            embedding_model="distilbert-base-multilingual-cased",
+            model_version=retriever_model_version,
+            use_gpu=gpu_available,
+            model_format="transformers",
+            pooling_strategy="reduce_max",
+            emb_extraction_layer=-1,
+        )
+
+#def sbert_distiluse(document_store, retriever_model_version, gpu_available)
+#        retriever = EmbeddingRetriever(
+#            document_store=document_store,
+#            embedding_model="distiluse-base-multilingual-cased",
+#            use_gpu=GPU_AVAILABLE,
+#            model_format="sentence_transformers",
+#            pooling_strategy="reduce_max",
+#            emb_extraction_layer=-1,
+#        )
+
+
+def dpr(document_store, dpr_model_version, gpu_available):
+    return DensePassageRetriever(
+            document_store=document_store,
+            query_embedding_model="etalab-ia/dpr-question_encoder-fr_qa-camembert",
+            passage_embedding_model="etalab-ia/dpr-ctx_encoder-fr_qa-camembert",
+            model_version=dpr_model_version,
+            infer_tokenizer_classes=True,
+            use_gpu=gpu_available,
+        )
+
+def title(document_store, retriever_model_version, gpu_available):
+    return TitleEmbeddingRetriever(
+            document_store=document_store,
+            embedding_model="distilbert-base-multilingual-cased",
+            model_version=retriever_model_version,
+            use_gpu=gpu_available,
+            model_format="transformers",
+            pooling_strategy="reduce_max",
+            emb_extraction_layer=-1,
+        )
+
+

--- a/src/evaluation/utils/pipelines/custom_pipelines.py
+++ b/src/evaluation/utils/pipelines/custom_pipelines.py
@@ -1,0 +1,557 @@
+"""
+This module contains functions that return haystack pipelines or classes that
+are subclasses of BaseStandardPipeline.
+"""
+
+from copy import deepcopy
+from typing import Dict, List, Optional
+
+from haystack.pipeline import BaseStandardPipeline, Pipeline
+from haystack.reader.base import BaseReader
+from haystack.retriever.base import BaseRetriever
+from haystack.schema import BaseComponent
+
+from deployment.roles.haystack.files.custom_component import \
+    MergeOverlappingAnswers, JoinDocumentsCustom, JoinAnswers, \
+    AnswerifyDocuments, StripLeadingSpace
+
+import src.evaluation.utils.pipelines.components.document_stores as document_stores
+import src.evaluation.utils.pipelines.components.evals as evals
+import src.evaluation.utils.pipelines.components.readers as readers
+import src.evaluation.utils.pipelines.components.retrievers as retrievers
+
+# TODO: Obsolete?
+class TitleQAPipeline(BaseStandardPipeline):
+    def __init__(self, retriever: BaseRetriever):
+        """
+        Initialize a Pipeline for finding documents with a title similar to the query using semantic document search.
+
+        :param retriever: Retriever instance
+        """
+        self.pipeline = Pipeline()
+        self.pipeline.add_node(component=retriever, name="Retriever", inputs=["Query"])
+
+    def run(
+        self,
+        query: str,
+        filters: Optional[Dict] = None,
+        top_k_retriever: Optional[int] = None,
+    ):
+        output = self.pipeline.run(
+            query=query, filters=filters, top_k_retriever=top_k_retriever
+        )
+        documents = output["documents"]
+
+        results: Dict = {"query": query, "answers": []}
+        for doc in documents:
+            cur_answer = {
+                "query": doc.meta["name"],
+                "answer": doc.text,
+                "document_id": doc.id,
+                "context": doc.text,
+                "score": doc.score,
+                "probability": doc.probability,
+                "offset_start": 0,
+                "offset_end": len(doc.text),
+                "meta": doc.meta,
+            }
+
+            results["answers"].append(cur_answer)
+        return results
+
+
+# TODO: Obsolete?
+class TitleBM25QAPipeline(BaseStandardPipeline):
+    def __init__(
+        self,
+        reader: BaseReader,
+        retriever_title: BaseRetriever,
+        retriever_bm25: BaseRetriever,
+        k_title_retriever: int,
+        k_bm25_retriever: int,
+    ):
+        """
+        Initialize a Pipeline for Extractive Question Answering. This Pipeline is based on two retrievers and a reader.
+        The two retrievers used for this pipeline are :
+
+            - A TitleEmbeddingRetriever
+            - An ElasticsearchRetriever
+        The output of the two retrievers are concatenated based on the number of k_retriever passed for each retrievers.
+
+        :param reader: Reader instance :param retriever: Retriever instance :param k_title_retriever: int :param
+        k_bm25_retriever: int
+        """
+        self.k_title_retriever = k_title_retriever
+        self.k_bm25_retriever = k_bm25_retriever
+        self.pipeline = Pipeline()
+        self.pipeline.add_node(
+            component=retriever_bm25, name="Retriever_bm25", inputs=["Query"]
+        )
+        self.pipeline.add_node(
+            component=retriever_title, name="Retriever_title", inputs=["Query"]
+        )
+        self.pipeline.add_node(
+            component=JoinDocumentsCustom(ks_retriever=[k_bm25_retriever, k_title_retriever]),
+            name="JoinResults",
+            inputs=["Retriever_bm25", "Retriever_title"],
+        )
+        self.pipeline.add_node(
+            component=reader, name="QAReader", inputs=["JoinResults"]
+        )
+
+    def run(
+        self,
+        query: str,
+        filters: Optional[Dict] = None,
+        top_k_retriever: int = 10,
+        top_k_reader: int = 10,
+    ):
+        assert top_k_retriever <= max(
+            self.k_title_retriever, self.k_bm25_retriever
+        ), "Be carefull, the pipeline was run with top_k_retriever that is greater than the k_retriever declared at instanciation"
+        output = self.pipeline.run(
+            query=query,
+            filters=filters,
+            top_k_retriever=top_k_retriever,
+            top_k_reader=top_k_reader,
+        )
+        return output
+
+
+
+
+def retriever_reader(reader, retriever, eval_retriever, eval_reader):
+    """
+    Returns an Evaluation Pipeline for Extractive Question Answering. This Pipeline is based on retriever reader architecture.
+    it includes two evaluation nodes :
+        - An EvalRetriever node after Retriever
+        - An EvalReader node after RetrReader
+
+    :param reader: Reader instance
+    :param retriever: Retriever instance
+    :param eval_retriever: EvalRetriever instance or None
+    :param eval_reader: EvalReader instance or None
+    """
+
+    pipeline = Pipeline()
+    pipeline.add_node(
+            component=retriever,
+            name="Retriever",
+            inputs=["Query"])
+
+    if eval_retriever:
+        pipeline.add_node(
+                component=eval_retriever,
+                name="EvalRetriever",
+                inputs=["Retriever"])
+        pipeline.add_node(
+                component=reader,
+                name="Reader",
+                inputs=["EvalRetriever"])
+    else:
+        pipeline.add_node(
+                component=reader,
+                name="Reader",
+                inputs=["Retriever"])
+
+    pipeline.add_node(
+            component=MergeOverlappingAnswers(),
+            name="MergeOverlappingAnswers",
+            inputs=["Reader"])
+    pipeline.add_node(
+            component=StripLeadingSpace(),
+            name='StripLeadingSpace',
+            inputs=['MergeOverlappingAnswers'])
+
+    if eval_reader:
+        pipeline.add_node(
+                component=eval_reader,
+                name="EvalReader",
+                inputs=["StripLeadingSpace"])
+
+    return pipeline
+
+
+
+def retriever_bm25(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor):
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname, elasticsearch_port,
+            similarity = "cosine", embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    retriever = retrievers.bm25(document_store=document_store)
+
+    p = Pipeline()
+    p.add_node(component=retriever, name="Retriever", inputs=["Query"])
+
+    return p
+
+
+
+
+def retriever_sbert(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor,
+        retriever_model_version,
+        gpu_available):
+
+    document_store = document_stores.elasticsearch(
+        elasticsearch_hostname, elasticsearch_port,
+        similarity = "cosine", embedding_dim = 768,
+        title_boosting_factor = title_boosting_factor)
+
+    retriever = retrievers.sbert(document_store, retriever_model_version,
+            gpu_available)
+
+    p = Pipeline()
+    p.add_node(component=retriever, name="Retriever", inputs=["Query"])
+
+    return p
+
+
+
+
+def retriever_google(
+            elasticsearch_hostname,
+            elasticsearch_port,
+            title_boosting_factor,
+            google_retriever_website):
+
+        document_store = document_stores.elasticsearch(
+                elasticsearch_hostname, elasticsearch_port,
+                similarity = "cosine", embedding_dim = 768,
+                title_boosting_factor = title_boosting_factor)
+
+        retriever = retrievers.google(document_store, google_retriever_website)
+
+        p = Pipeline()
+        p.add_node(component=retriever, name="Retriever", inputs=["Query"])
+
+        return p
+
+
+
+
+def retriever_epitca(
+            elasticsearch_hostname,
+            elasticsearch_port,
+            title_boosting_factor):
+
+        document_store = document_stores.elasticsearch(
+                elasticsearch_hostname, elasticsearch_port,
+                similarity = "cosine", embedding_dim = 768,
+                title_boosting_factor = title_boosting_factor)
+
+        retriever = retrievers.epitca(document_store)
+
+        p = Pipeline()
+        p.add_node(component=retriever, name="Retriever", inputs=["Query"])
+
+        return p
+
+
+
+
+def retriever_reader_bm25(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor,
+        reader_model_version,
+        gpu_id,
+        k_reader_per_candidate):
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname, elasticsearch_port,
+            similarity = "cosine", embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    retriever = retrievers.bm25(document_store)
+
+    reader = readers.transformers_reader(reader_model_version, gpu_id,
+            k_reader_per_candidate)
+
+    eval_retriever = evals.piaf_eval_retriever()
+    eval_reader = evals.piaf_eval_reader()
+
+    return retriever_reader(
+            reader = reader,
+            retriever = retriever,
+            eval_retriever = eval_retriever,
+            eval_reader = eval_reader)
+
+
+
+
+def retriever_reader_sbert(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor,
+        retriever_model_version,
+        reader_model_version,
+        gpu_id,
+        k_reader_per_candidate):
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname, elasticsearch_port,
+            similarity = "cosine", embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    gpu_available = gpu_id >= 0
+
+    retriever = retrievers.sbert(document_store, retriever_model_version,
+            gpu_available)
+
+    reader = readers.transformers_reader(reader_model_version, gpu_id, 
+            k_reader_per_candidate)
+
+    eval_retriever = evals.piaf_eval_retriever()
+    eval_reader = evals.piaf_eval_reader()
+
+    return retriever_reader(
+            reader = reader,
+            retriever = retriever,
+            eval_retriever = eval_retriever,
+            eval_reader = eval_reader)
+
+
+
+
+def retriever_reader_dpr(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor,
+        dpr_model_version,
+        reader_model_version,
+        gpu_id,
+        k_reader_per_candidate):
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname, elasticsearch_port,
+            similarity = "dot_product", embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    gpu_available = gpu_id >= 0
+
+    retriever = retrievers.dpr(document_store, dpr_model_version,
+            gpu_available)
+
+    reader = readers.transformers_reader(reader_model_version, gpu_id,
+            k_reader_per_candidate)
+
+    eval_retriever = evals.piaf_eval_retriever()
+    eval_reader = evals.piaf_eval_reader()
+
+    return retriever_reader(
+            reader = reader,
+            retriever = retriever,
+            eval_retriever = eval_retriever,
+            eval_reader = eval_reader)
+
+
+
+
+def retriever_reader_title_bm25(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor,
+        retriever_model_version,
+        reader_model_version,
+        gpu_id,
+        k_reader_per_candidate,
+        k_title_retriever,
+        k_bm25_retriever):
+    """
+    Returns an Evaluation Pipeline for Extractive Question Answering. This Pipeline is based on on two retrievers and a reader.
+    The two retrievers used for this pipeline are :
+        - A TitleEmbeddingRetriever
+        - An ElasticsearchRetriever
+
+    it includes two evaluation nodes :
+        - An EvalRetriever node after Retriever
+        - An EvalReader node after RetrReader
+    """
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname, elasticsearch_port,
+            similarity = "cosine", embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    gpu_available = gpu_id >= 0
+
+    retriever_title = retrievers.title(document_store, retriever_model_version,
+            gpu_available)
+
+    retriever_bm25 = retrievers.bm25(document_store)
+
+    reader = readers.transformers_reader(reader_model_version, gpu_id, 
+            k_reader_per_candidate)
+
+    eval_retriever = evals.piaf_eval_retriever()
+    eval_reader = evals.piaf_eval_reader()
+
+    pipeline = Pipeline()
+    pipeline.add_node(
+            component=retriever_bm25,
+            name="Retriever_bm25",
+            inputs=["Query"])
+    pipeline.add_node(
+            component=retriever_title,
+            name="Retriever_title",
+            inputs=["Query"])
+    pipeline.add_node(
+            component=JoinDocumentsCustom(ks_retriever=[k_bm25_retriever,
+                k_title_retriever]),
+            name="JoinResults",
+            inputs=["Retriever_bm25", "Retriever_title"])
+
+    if eval_retriever:
+        pipeline.add_node(
+                component=eval_retriever,
+                name="EvalRetriever",
+                inputs=["JoinResults"])
+        pipeline.add_node(
+                component=reader,
+                name="Reader",
+                inputs=["EvalRetriever"])
+    else:
+        pipeline.add_node(
+                component=reader,
+                name="Reader",
+                inputs=["JoinResults"])
+
+    pipeline.add_node(
+            component=MergeOverlappingAnswers(),
+            name="MergeOverlappingAnswers",
+            inputs=["Reader"])
+    pipeline.add_node(
+            component=StripLeadingSpace(),
+            name='StripLeadingSpace',
+            inputs=['MergeOverlappingAnswers'])
+
+    if eval_reader:
+        pipeline.add_node(
+                component=eval_reader,
+                name="EvalReader",
+                inputs=["StripLeadingSpace"])
+
+    return pipeline
+
+
+
+
+def retriever_reader_title(
+        elasticsearch_hostname,
+        elasticsearch_port,
+        title_boosting_factor,
+        retriever_model_version,
+        reader_model_version,
+        gpu_id,
+        k_reader_per_candidate):
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname, elasticsearch_port,
+            similarity = "cosine", embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    gpu_available = gpu_id >= 0
+
+    retriever = retrievers.title(document_store, retriever_model_version,
+            gpu_available)
+
+    reader = readers.transformers_reader(reader_model_version, gpu_id,
+            k_reader_per_candidate)
+
+    eval_retriever = evals.piaf_eval_retriever()
+    eval_reader = evals.piaf_eval_reader()
+
+    return retriever_reader(
+            reader = reader,
+            retriever = retriever,
+            eval_retriever = eval_retriever,
+            eval_reader = eval_reader)
+
+
+
+
+def hottest_reader_pipeline(
+            elasticsearch_hostname,
+            elasticsearch_port,
+            title_boosting_factor,
+            retriever_model_version,
+            reader_model_version,
+            gpu_id,
+            k_reader_per_candidate,
+            k_title_retriever,
+            k_bm25_retriever,
+            threshold_score):
+    """
+    Initialize a Pipeline for Extractive Question Answering. This Pipeline is based on two retrievers and a reader.
+    The two retrievers used for this pipeline are :
+
+        - A TitleEmbeddingRetriever
+        - An ElasticsearchRetriever
+    The output of the two retrievers are concatenated based on the number of k_retriever passed for each retrievers.
+
+    :param reader: Reader instance :param retriever: Retriever instance :param k_title_retriever: int :param
+    k_bm25_retriever: int
+    """
+
+    document_store = document_stores.elasticsearch(
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            similarity = "cosine",
+            embedding_dim = 768,
+            title_boosting_factor = title_boosting_factor)
+
+    retriever_title = retrievers.title(
+            document_store = document_store,
+            retriever_model_version = retriever_model_version,
+            gpu_available = gpu_id >= 0)
+
+    retriever_bm25 = retrievers.bm25(document_store)
+
+    reader = readers.transformers_reader(reader_model_version, gpu_id,
+            k_reader_per_candidate)
+
+    pipeline = Pipeline()
+    pipeline.add_node(
+        component=retriever_bm25,
+        name="Retriever_bm25",
+        inputs=["Query"])
+    pipeline.add_node(
+        component=retriever_title,
+        name="Retriever_title",
+        inputs=["Query"])
+    pipeline.add_node(
+        component=JoinDocumentsCustom(ks_retriever=[k_bm25_retriever,
+            k_title_retriever]),
+        name="JoinRetrieverResults",
+        inputs=["Retriever_bm25", "Retriever_title"])
+    pipeline.add_node(
+        component=reader,
+        name="Reader",
+        inputs=["JoinRetrieverResults"])
+    pipeline.add_node(
+        component=AnswerifyDocuments(),
+        name="AnswerFromRetrievers",
+        inputs=["JoinRetrieverResults"])
+    pipeline.add_node(
+        component=JoinAnswers(threshold_score=threshold_score),
+        name="JoinResults", 
+        inputs=["Query","Reader", "AnswerFromRetrievers"])
+    pipeline.add_node(
+            component=MergeOverlappingAnswers(),
+            name="MergeOverlappingAnswers",
+            inputs=["Reader"])
+    pipeline.add_node(component=StripLeadingSpace(),
+            name='StripLeadingSpace',
+            inputs=['MergeOverlappingAnswers'])
+
+    return pipeline
+
+

--- a/src/evaluation/utils/utils_eval.py
+++ b/src/evaluation/utils/utils_eval.py
@@ -460,7 +460,6 @@ def full_eval_retriever_reader(
         } for l in labels
     }
 
-
     answers = []
     for q, l in q_to_l_dict.items():
         ans = pipeline.run(

--- a/test/test_title_qa_pipeline.py
+++ b/test/test_title_qa_pipeline.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from haystack.document_store.base import BaseDocumentStore
 
 from src.evaluation.utils.utils_eval import eval_titleQA_pipeline
-from src.evaluation.utils.custom_pipelines import TitleQAPipeline
+from src.evaluation.utils.pipelines.custom_pipelines import TitleQAPipeline
 
 
 @pytest.mark.elasticsearch


### PR DESCRIPTION
## Reference to a related issue

This changes precedes using YAML for pipeline creation, #39.

## Why is the change needed

Pipeline construction in piaf-ml is scattered accross different scripts, which creates a risk of discrepancy between different evaluation scripts. For example, the retrievers used in the retriever only and the retriever + reader evaluation scripts are not always consistent. This refactoring puts pipeline creation in a single module which serves as a central reference for pipeline definition.


## Description of the change

This is a lot of moving code around, here is a little summary of the refactoring to help you follow along:

- Move pipeline construction originally in `src/evaluation/retriever/retriever_eval_squad.py` and `src/evaluation/retriever_reader/retriever_reader_eval_squad.py` to the new module src.evaluation.utils.pipelines
- This root module contains functions that build pipelines given a parameter dictionnary and a few other arguments. They are responsible for calling the right pipeline constructor function from the values in the parameter dict.
- There are two submodules: `custom_pipelines` and `components`.
- The `custom_pipelines` submodule contains functions that build pipelines.
- The `components` submodule contains functions that create the custom components used in the pipelines defined in the `custom_pipelines` submodule.


## (Optionnal) Description or justification of specific technical choices that were made

Comment on using bare haystack Pipeline objects:  I eliminated the use of custom pipeline classes and use bare "haystack" Pipeline objects instead. The reason for this is that production does not use these custom classes and we want piaf-ml to be closer to production to reduce the risk of discrepancy between piaf-ml and prod. Also, the custom pipelines didn't do much beside building the bare Pipeline instance. (Some custom classes remain but those aren't used in the retriever and retriever+reader evaluation scripts.)


## @mentions of the persons responsible for reviewing 
