### PR TITLE
Generate YAML pipelines during evaluation

### DIFF
--- a/deployment/roles/haystack/files/custom_component.py
+++ b/deployment/roles/haystack/files/custom_component.py
@@ -20,6 +20,11 @@ class LabelElasticsearchRetriever(ElasticsearchRetriever):
     def __init__(self, document_store: ElasticsearchDocumentStore, top_k: int = 10, custom_query: str = None,
                  weight_when_document_found: int = 99):
         super().__init__(document_store, top_k, custom_query)
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(document_store = document_store, top_k = top_k, custom_query = custom_query,
+                 weight_when_document_found = weight_when_document_found)
+
         self.weight_when_document_found = weight_when_document_found
 
     def retrieve(self, query: str, filters: dict = None, top_k: Optional[int] = None, index: str = None) -> List[Document]:
@@ -50,6 +55,19 @@ class TitleEmbeddingRetriever(EmbeddingRetriever):
     ):
         super().__init__(document_store, embedding_model, model_version, use_gpu, model_format, pooling_strategy,
                          emb_extraction_layer, top_k)
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(
+            document_store = document_store,
+            embedding_model = embedding_model,
+            model_version = model_version,
+            use_gpu = use_gpu,
+            model_format = model_format,
+            pooling_strategy = pooling_strategy,
+            emb_extraction_layer = emb_extraction_layer,
+            top_k = top_k,
+            weight_when_document_found = weight_when_document_found)
+
         self.weight_when_document_found = weight_when_document_found
 
     def retrieve(self, query: str, filters: dict = None, top_k: Optional[int] = None, index: str = None) -> List[Document]:
@@ -83,6 +101,10 @@ class JoinDocumentsCustom(BaseComponent):
         :param ks_retriever: A node-wise list(length of list must be equal to the number of input nodes) of k_retriever kept for
                         the concatenation of the retrievers in the nodes. If set to None, the number of documents retrieved will be used
         """
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(ks_retriever = ks_retriever)
+
         self.ks_retriever = ks_retriever
 
     def run(self, **kwargs):
@@ -112,6 +134,12 @@ class AnswerifyDocuments(BaseComponent):
     This component is used to transform the documents retrieved in a shape that can be used like a Reader answer.
     """
     outgoing_edges = 1
+
+    def __init__(self):
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config()
+
 
     def run(self, **kwargs):
         query = kwargs["query"]
@@ -155,6 +183,11 @@ class JoinAnswers(BaseComponent):
         """
         :param threshold_score: The threshold that will be used for keeping or not the answer from the readers
         """
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(threshold_score = threshold_score, top_k = top_k,
+                max_reader_answer = max_reader_answer)
+
         self.threshold_score = threshold_score
         self.top_k = top_k
         self.max_reader_answer = max_reader_answer
@@ -199,6 +232,11 @@ class MergeOverlappingAnswers(BaseComponent):
     outgoing_edges = 1
 
     def __init__(self, minimum_overlap_contexts=0.75, minimum_overlap_answers=0.25):
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(minimum_overlap_contexts = minimum_overlap_contexts, 
+                minimum_overlap_answers = minimum_overlap_answers)
+
         self.minimum_overlap_contexts = minimum_overlap_contexts
         self.minimum_overlap_answers = minimum_overlap_answers
 
@@ -272,6 +310,12 @@ class RankAnswersWithWeigth(BaseComponent):
     """
     outgoing_edges = 1
 
+    def __init__(self):
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config()
+
+
     def run(self, **kwargs):
         answers = kwargs["answers"]
         answers_dict_format = [a if isinstance(a, dict) else a.to_dict() for a in answers]
@@ -287,6 +331,11 @@ class StripLeadingSpace(BaseComponent):
     by a TransformersReader since transformers version 4.3.
     """
     outgoing_edges = 1
+
+    def __init__(self):
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config()
 
     def run(self, **kwargs):
         answers = kwargs["answers"]

--- a/src/evaluation/retriever/retriever_eval_squad.py
+++ b/src/evaluation/retriever/retriever_eval_squad.py
@@ -36,7 +36,8 @@ if GPU_AVAILABLE:
 else:
     gpu_id = -1
 
-def single_run(parameters, elasticsearch_hostname, elasticsearch_port):
+def single_run(parameters, elasticsearch_hostname, elasticsearch_port,
+        yaml_dir_prefix = "./output/pipelines/retriever"):
     """
     Runs a grid search config 
 
@@ -54,9 +55,11 @@ def single_run(parameters, elasticsearch_hostname, elasticsearch_port):
     delete_indices(index="document_elasticsearch")
     delete_indices(index="label_elasticsearch")
 
-    p = pipelines.retriever(parameters, elasticsearch_hostname, 
-            elasticsearch_port,
-            gpu_id = gpu_id)
+    p = pipelines.retriever(parameters,
+            elasticsearch_hostname = elasticsearch_hostname, 
+            elasticsearch_port = elasticsearch_port,
+            gpu_id = gpu_id,
+            yaml_dir_prefix = yaml_dir_prefix)
 
     document_store = p.get_node("Retriever").document_store
 
@@ -135,6 +138,7 @@ if __name__ == "__main__":
     for param in tqdm(parameters_grid, desc="GridSearch"):
         # START XP
         run_results = single_run(param, elasticsearch_hostname,
-                elasticsearch_port)
+                elasticsearch_port,
+                yaml_dir_prefix = "./output/pipelines/retriever")
         # all_results.append(run_results)
         save_results(result_file_path=result_file_path, results_list=run_results)

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -52,6 +52,7 @@ def single_run(
         gpu_id = -1,
         elasticsearch_hostname = "localhost",
         elasticsearch_port = 9200,
+        yaml_dir_prefix = "./output/pipelines/retriever_reader",
         ):
     """
     Perform one run of the pipeline under testing with the parameters given in the config file. The results are
@@ -63,7 +64,8 @@ def single_run(
     p = pipelines.retriever_reader(parameters,
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
-            gpu_id = gpu_id)
+            gpu_id = gpu_id,
+            yaml_dir_prefix = yaml_dir_prefix)
 
     # Get all the retrievers used in the pipelines.
     retrievers = [p.get_node(name)
@@ -145,7 +147,8 @@ def single_run(
 
 def optimize(parameters, n_calls, result_file_path, gpu_id=-1,
              elasticsearch_hostname="localhost",
-             elasticsearch_port=9200):
+             elasticsearch_port=9200,
+             yaml_dir_prefix="./output/pipelines/retriever_reader"):
     """ Returns a list of n_calls tuples [(x1, v1), ...] where the lists xi are
     the parameter values for each evaluation and the dictionaries vi are the run
     results. The parameter values for the successive runs are determined by the
@@ -162,7 +165,8 @@ def optimize(parameters, n_calls, result_file_path, gpu_id=-1,
     def single_run_optimization(params):
         result = single_run(params, gpu_id = gpu_id,
                             elasticsearch_hostname = elasticsearch_hostname, 
-                            elasticsearch_port = elasticsearch_port)
+                            elasticsearch_port = elasticsearch_port,
+                            yaml_dir_prefix = yaml_dir_prefix)
 
         results.append((None, parameters, result))
 
@@ -182,7 +186,8 @@ def optimize(parameters, n_calls, result_file_path, gpu_id=-1,
 
 def grid_search(parameters, mlflow_client, experiment_name, use_cache=False,
                 result_file_path=Path("./output/results_reader.csv"), gpu_id=-1,
-                elasticsearch_hostname="localhost", elasticsearch_port=9200):
+                elasticsearch_hostname="localhost", elasticsearch_port=9200,
+                yaml_dir_prefix="./output/pipelines/retriever_reader"):
     """ Returns a generator of tuples [(id1, x1, v1), ...] where id1 is the run
     id, the lists xi are the parameter values for each evaluation and the
     dictionaries vi are the run results. The parameter values for each
@@ -214,7 +219,8 @@ def grid_search(parameters, mlflow_client, experiment_name, use_cache=False,
             logging.info(f"Doing run with config : {param}")
             run_results = single_run(param, gpu_id = gpu_id,
                                      elasticsearch_hostname = elasticsearch_hostname,
-                                     elasticsearch_port = elasticsearch_port)
+                                     elasticsearch_port = elasticsearch_port,
+                                     yaml_dir_prefix = yaml_dir_prefix)
 
             # For debugging purpose, we keep a copy of the results in a csv form
             save_results(result_file_path=result_file_path,
@@ -232,7 +238,8 @@ def tune_pipeline(
         parameters,
         parameter_tuning_options,
         elasticsearch_hostname,
-        elasticsearch_port):
+        elasticsearch_port,
+        yaml_dir_prefix):
     """
     Run the parameter tuning method for the whole pipeline based on the
     parameters.
@@ -264,7 +271,8 @@ def tune_pipeline(
             result_file_path=Path("./output/optimize_result.z"),
             gpu_id=gpu_id,
             elasticsearch_hostname=elasticsearch_hostname,
-            elasticsearch_port=elasticsearch_port)
+            elasticsearch_port=elasticsearch_port,
+            yaml_dir_prefix=yaml_dir_prefix)
 
     elif parameter_tuning_options["tuning_method"] == "grid_search":
         runs = grid_search(
@@ -275,7 +283,8 @@ def tune_pipeline(
             gpu_id=gpu_id,
             result_file_path=Path("./output/results_reader.csv"),
             elasticsearch_hostname=elasticsearch_hostname,
-            elasticsearch_port=elasticsearch_port)
+            elasticsearch_port=elasticsearch_port,
+            yaml_dir_prefix=yaml_dir_prefix)
 
     else:
         print("Unknown parameter tuning method: ",
@@ -293,13 +302,17 @@ if __name__ == "__main__":
     from src.evaluation.config.retriever_reader_eval_squad_config import \
         parameters, parameter_tuning_options
 
+    yaml_dir_prefix = "./output/pipelines/retriever_reader"
+
     runs = tune_pipeline(
         parameters,
         parameter_tuning_options,
         elasticsearch_hostname=os.getenv("ELASTICSEARCH_HOSTNAME") or "localhost",
-        elasticsearch_port=int((os.getenv("ELASTICSEARCH_PORT")) or 9200))
+        elasticsearch_port=int((os.getenv("ELASTICSEARCH_PORT")) or 9200),
+        yaml_dir_prefix = yaml_dir_prefix)
 
     for (run_id, params, results) in runs:
         clean_log()
-        mlflow_log_run(params, results, idx=run_id)
+        mlflow_log_run(params, results, idx = run_id,
+                yaml_dir_prefix = yaml_dir_prefix)
 

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -60,8 +60,10 @@ def single_run(
 
     evaluation_data = Path(parameters["squad_dataset"])
 
-    p = pipelines.retriever_reader(parameters, gpu_id, elasticsearch_hostname,
-            elasticsearch_port)
+    p = pipelines.retriever_reader(parameters,
+            elasticsearch_hostname = elasticsearch_hostname,
+            elasticsearch_port = elasticsearch_port,
+            gpu_id = gpu_id)
 
     # Get all the retrievers used in the pipelines.
     retrievers = [p.get_node(name)

--- a/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
+++ b/src/evaluation/retriever_reader/retriever_reader_eval_squad.py
@@ -198,7 +198,7 @@ def grid_search(parameters, mlflow_client, experiment_name, use_cache=False,
             desc="GridSearch",
             unit="config",
     ):
-        add_extra_params(param)
+        enriched_param = add_extra_params(param)
         if (
                 idx in list_past_run_names.keys() and use_cache
         ):  # run not done
@@ -218,7 +218,7 @@ def grid_search(parameters, mlflow_client, experiment_name, use_cache=False,
 
             # For debugging purpose, we keep a copy of the results in a csv form
             save_results(result_file_path=result_file_path,
-                         results_list={**run_results, **param})
+                         results_list={**run_results, **enriched_param})
 
             # update list of past experiments
             list_past_run_names = get_list_past_run(mlflow_client, experiment_name)

--- a/src/evaluation/utils/epitca_retriever.py
+++ b/src/evaluation/utils/epitca_retriever.py
@@ -32,6 +32,11 @@ class EpitcaRetriever(BaseRetriever):
             documents ids returned by Epitca as well as the document id for the
             expected response.
         """
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(document_store = document_store, top_k = top_k,
+                epitca_perf_file = epitca_perf_file)
+
         self.document_store = document_store
         self.top_k = top_k
         self.epitca_perf_file = Path(epitca_perf_file)

--- a/src/evaluation/utils/google_retriever.py
+++ b/src/evaluation/utils/google_retriever.py
@@ -33,6 +33,11 @@ class GoogleRetriever(BaseRetriever):
             :param retrieved_search_file: the path to the backup of the links retrieved by google. This must be a json
         """
 
+        # save init parameters to enable export of component config as YAML
+        self.set_config(document_store = document_store, top_k = top_k,
+                website = website,
+                retrieved_search_file = retrieved_search_file)
+
         self.document_store = document_store
         self.top_k = top_k
         self.website = website

--- a/src/evaluation/utils/mlflow_management.py
+++ b/src/evaluation/utils/mlflow_management.py
@@ -17,11 +17,10 @@ def add_extra_params(dict_params: dict):
     extra_parameters = {
         "date": datetime.today().strftime("%Y-%m-%d_%H-%M-%S"),
         "hostname": socket.gethostname(),
+        "experiment_id": hashlib.md5(str(dict_params).encode("utf-8")).hexdigest()[:4]
     }
 
-    dict_params.update(extra_parameters)
-    experiment_id = hashlib.md5(str(dict_params).encode("utf-8")).hexdigest()[:4]
-    dict_params.update({"experiment_id": experiment_id})
+    return {**dict_params, **extra_parameters}
 
 
 def hash_piaf_code():

--- a/src/evaluation/utils/mlflow_management.py
+++ b/src/evaluation/utils/mlflow_management.py
@@ -9,6 +9,7 @@ import mlflow
 from dotenv import load_dotenv
 from tqdm import tqdm
 from src.evaluation.utils.logging_management import logger
+import src.evaluation.utils.pipelines as pipelines
 
 load_dotenv()
 
@@ -129,12 +130,19 @@ def mlflow_log_run(
         idx=None,
         root_log_path="./logs/root.log",
         pass_criteria=None,
+        yaml_dir_prefix="./output/pipelines"
         ):
     with mlflow.start_run(run_name=idx) as run:
         mlflow.log_params(params)
         mlflow.log_metrics(
             {k: v for k, v in retriever_reader_eval_results.items() if v is not None}
         )
+        yaml_path = pipelines.pipeline_dirpath(params, yaml_dir_prefix) \
+                / "pipelines.yaml"
+        try:
+            mlflow.log_artifact(yaml_path)
+        except Exception:
+            logger.error(f"Could not upload {yaml_path} to mlflow server.")
         if pass_criteria != None:
             mlflow.set_tag("pass_criteria", pass_criteria)
         logger.info(f"Run finished successfully")

--- a/src/evaluation/utils/pipelines/__init__.py
+++ b/src/evaluation/utils/pipelines/__init__.py
@@ -13,9 +13,10 @@ components used in the pipelines defined in the `custom_pipelines` submodule.
 """
 
 
-from pathlib import Path
-from haystack.pipeline import Pipeline
 import hashlib
+from haystack.pipeline import Pipeline
+import json
+from pathlib import Path
 
 import src.evaluation.utils.pipelines.custom_pipelines as custom_pipelines
 
@@ -172,7 +173,6 @@ def pipeline_to_yaml_and_back(pipeline, parameters, prefix = "./output/pipelines
     return Pipeline.load_from_yaml(yaml_path, overwrite_with_env_variables = False)
 
 def pipeline_dirpath(parameters, prefix = "./output/pipelines/"):
-    params_hash = hashlib.sha1(repr(frozenset(parameters.items())).encode()) \
-        .hexdigest()
+    params_hash = hashlib.sha1(json.dumps(parameters, sort_keys=True).encode()).hexdigest()
     path = Path(parameters["retriever_type"]) / params_hash
     return Path(prefix) / path

--- a/src/evaluation/utils/pipelines/__init__.py
+++ b/src/evaluation/utils/pipelines/__init__.py
@@ -64,7 +64,7 @@ def retriever(
     # Save the pipeline to yaml and load it back from yaml to make sure the 
     # pipeline being evaluated is build the same way as it is in prod.
     pipeline = pipeline_to_yaml_and_back(pipeline, parameters,
-            prefix = Path(yaml_dir_prefix) / "retriever")
+            prefix = Path(yaml_dir_prefix))
 
     return pipeline
 
@@ -153,7 +153,7 @@ def retriever_reader(
     # Save the pipeline to yaml and load it back from yaml to make sure the 
     # pipeline being evaluated is build the same way as it is in prod.
     pipeline = pipeline_to_yaml_and_back(pipeline, parameters,
-            prefix = Path(yaml_dir_prefix) / "retriever_reader")
+            prefix = Path(yaml_dir_prefix))
 
     return pipeline
 

--- a/src/evaluation/utils/pipelines/__init__.py
+++ b/src/evaluation/utils/pipelines/__init__.py
@@ -12,8 +12,10 @@ The `components` submodule contains functions that create the custom
 components used in the pipelines defined in the `custom_pipelines` submodule.
 """
 
+
 from pathlib import Path
 from haystack.pipeline import Pipeline
+import hashlib
 
 import src.evaluation.utils.pipelines.custom_pipelines as custom_pipelines
 
@@ -21,18 +23,19 @@ def retriever(
         parameters,
         elasticsearch_hostname,
         elasticsearch_port,
-        gpu_id = -1):
+        gpu_id = -1,
+        yaml_dir_prefix = "./output/pipelines/"):
 
     retriever_type = parameters["retriever_type"]
 
     if retriever_type == "bm25":
-        return custom_pipelines.retriever_bm25(
+        pipeline =  custom_pipelines.retriever_bm25(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"])
 
     elif retriever_type == "sbert":
-        return custom_pipelines.retriever_sbert(
+        pipeline = custom_pipelines.retriever_sbert(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -40,14 +43,14 @@ def retriever(
             gpu_available = gpu_id >= 0)
 
     elif retriever_type == "google":
-        return custom_pipelines.retriever_google(
+        pipeline = custom_pipelines.retriever_google(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
             google_retriever_website = parameters["google_retriever_website"])
 
     elif retriever_type == "epitca":
-        return custom_pipelines.retriever_epitca(
+        pipeline = custom_pipelines.retriever_epitca(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"])
@@ -57,19 +60,27 @@ def retriever(
             f"You chose {retriever_type}. Choose one from bm25, sbert, google or dpr"
         )
 
+    # Save the pipeline to yaml and load it back from yaml to make sure the 
+    # pipeline being evaluated is build the same way as it is in prod.
+    pipeline = pipeline_to_yaml_and_back(pipeline, parameters,
+            prefix = Path(yaml_dir_prefix) / "retriever")
+
+    return pipeline
+
 
 def retriever_reader(
         parameters,
-        gpu_id = -1,
         elasticsearch_hostname = "localhost",
         elasticsearch_port = 9200,
+        gpu_id = -1,
+        yaml_dir_prefix = "./output/pipelines",
         ):
 
     # Gather parameters
     retriever_type = parameters["retriever_type"]
 
     if retriever_type == "bm25":
-        return custom_pipelines.retriever_reader_bm25(
+        pipeline = custom_pipelines.retriever_reader_bm25(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -78,7 +89,7 @@ def retriever_reader(
             k_reader_per_candidate = parameters["k_reader_per_candidate"])
 
     elif retriever_type == "sbert":
-        return custom_pipelines.retriever_reader_sbert(
+        pipeline = custom_pipelines.retriever_reader_sbert(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -88,7 +99,7 @@ def retriever_reader(
             k_reader_per_candidate = parameters["k_reader_per_candidate"])
 
     elif retriever_type == "dpr":
-        return custom_pipelines.retriever_reader_dpr(
+        pipeline = custom_pipelines.retriever_reader_dpr(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -98,7 +109,7 @@ def retriever_reader(
             k_reader_per_candidate = parameters["k_reader_per_candidate"])
 
     elif retriever_type == "title_bm25":
-        return custom_pipelines.retriever_reader_title_bm25(
+        pipeline = custom_pipelines.retriever_reader_title_bm25(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -110,7 +121,7 @@ def retriever_reader(
             k_bm25_retriever = parameters["k_retriever"])
 
     elif retriever_type == "title":
-        return custom_pipelines.retriever_reader_title(
+        pipeline = custom_pipelines.retriever_reader_title(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -120,7 +131,7 @@ def retriever_reader(
             k_reader_per_candidate = parameters["k_reader_per_candidate"])
 
     elif retriever_type == "hot_reader":
-        return custom_pipelines.hottest_reader_pipeline(
+        pipeline = custom_pipelines.hottest_reader_pipeline(
             elasticsearch_hostname = elasticsearch_hostname,
             elasticsearch_port = elasticsearch_port,
             title_boosting_factor = parameters["boosting"],
@@ -137,3 +148,31 @@ def retriever_reader(
             f"You chose {retriever_type}. Choose one from bm25, sbert, dpr, title_bm25 or title."
         )
         raise Exception(f"Wrong retriever type for {retriever_type}.")
+
+    # Save the pipeline to yaml and load it back from yaml to make sure the 
+    # pipeline being evaluated is build the same way as it is in prod.
+    pipeline = pipeline_to_yaml_and_back(pipeline, parameters,
+            prefix = Path(yaml_dir_prefix) / "retriever_reader")
+
+    return pipeline
+
+def pipeline_to_yaml_and_back(pipeline, parameters, prefix = "./output/pipelines/"):
+    dirname = pipeline_dirpath(parameters, prefix)
+    dirname.mkdir(parents = True, exist_ok = True)
+
+    yaml_path = dirname / "pipelines.yaml"
+    pipeline.save_to_yaml(yaml_path, return_defaults = True)
+
+    params_path = dirname / "params.py"
+    with open(params_path, "w") as f:
+        f.write(repr(parameters))
+
+    # Turn off overwriting with env variable to avoid accidentally constructing
+    # a different pipeline that the one defined in the yaml.
+    return Pipeline.load_from_yaml(yaml_path, overwrite_with_env_variables = False)
+
+def pipeline_dirpath(parameters, prefix = "./output/pipelines/"):
+    params_hash = hashlib.sha1(repr(frozenset(parameters.items())).encode()) \
+        .hexdigest()
+    path = Path(parameters["retriever_type"]) / params_hash
+    return Path(prefix) / path

--- a/src/evaluation/utils/utils_eval.py
+++ b/src/evaluation/utils/utils_eval.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Dict, List, Union
 
 import pandas as pd
+from haystack.schema import BaseComponent
 from haystack.document_store.base import BaseDocumentStore
 from haystack.eval import eval_counts_reader, calculate_reader_metrics, \
     _count_no_answer, _calculate_f1, _count_overlap, _count_exact_match, \
@@ -201,7 +202,7 @@ def eval_retriever_reader(
     return metrics
 
 
-class PiafEvalRetriever(EvalDocuments):
+class PiafEvalRetriever(EvalDocuments, BaseComponent):
     """
     This is a pipeline node that should be placed after a Retriever in order to assess its performance. Performance
     metrics are stored in this class and updated as each sample passes through it.
@@ -210,6 +211,9 @@ class PiafEvalRetriever(EvalDocuments):
 
     def __init__(self, debug: bool = False, open_domain: bool = False):
         super().__init__(debug, open_domain)
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config(debug = debug, open_domain = open_domain)
 
         self.summed_avg_precision = 0.0
         self.summed_reciprocal_rank = 0.0
@@ -319,7 +323,7 @@ class PiafEvalRetriever(EvalDocuments):
         }
 
 
-class PiafEvalReader(EvalAnswers):
+class PiafEvalReader(EvalAnswers, BaseComponent):
     """
     This is a pipeline node that should be placed after a Reader in order to assess the performance of the Reader
     To extract the metrics in a dict form use EvalReader.get_metrics().
@@ -328,6 +332,9 @@ class PiafEvalReader(EvalAnswers):
     def __init__(self):
 
         super().__init__(debug=True, open_domain=False)
+
+        # save init parameters to enable export of component config as YAML
+        self.set_config()
 
         self.metric_counts = {
             "correct_no_answers_top1": 0,

--- a/test/test_pipelines_build.py
+++ b/test/test_pipelines_build.py
@@ -1,0 +1,89 @@
+import pytest
+
+import src.evaluation.utils.pipelines as pipelines
+
+def test_retriever_build():
+    parameters = {
+        "k": 1,
+        "retriever_type": "bm25",
+        "retriever_model_version": "1a01b38498875d45f69b2a6721bf6fe87425da39",
+        "google_retriever_website": 'service-public.fr',
+        "squad_dataset": "./test/samples/squad/tiny.json",
+        # Path to the Epitca performance file or None. Needed when using the
+        # retriever_type 'epitca'.
+        #"epitca_perf_file": "./clients/cnil/knowledge_base/raw_and_preparation/epitca_perf_V2.json",
+        "epitca_perf_file": None,
+        "filter_level": None,
+        "boosting": 1,
+        "preprocessing": False,
+        "split_by": "word",  # Can be "word", "sentence", or "passage"
+        "split_length": 200,
+        "split_respect_sentence_boundary": True,
+    }
+
+    parameters["retriever_type"] = "bm25"
+    pipelines.retriever(parameters, "localhost", "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever")
+
+    parameters["retriever_type"] = "sbert"
+    pipelines.retriever(parameters, "localhost", "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever")
+
+    parameters["retriever_type"] = "google"
+    pipelines.retriever(parameters, "localhost", "9200", gpu_id = -1,
+           yaml_dir_prefix = "output/test/pipelines/retriever")
+
+    parameters["retriever_type"] = "epitca"
+    pipelines.retriever(parameters, "localhost", "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever")
+
+
+
+def test_retriever_reader_build():
+    parameters = {
+        "k_retriever": 3,
+        "k_title_retriever" : 1, # must be present, but only used when retriever_type == title_bm25
+        "k_reader_per_candidate": 20,
+        "k_reader_total": 5,
+        "threshold_score": 1.00,# must be present, but only used when retriever_type == hot_reader
+        "reader_model_version": "053b085d851196110d7a83d8e0f077d0a18470be",
+        "retriever_model_version": "1a01b38498875d45f69b2a6721bf6fe87425da39",
+        "dpr_model_version": "v1.0",
+        "retriever_type": "bm25", # Can be bm25, sbert, dpr, title or title_bm25
+        "squad_dataset": "./test/samples/squad/tiny.json",
+        "filter_level": None,
+        "preprocessing": False,
+        "boosting" : 1, #default to 1
+        "split_by": "word",  # Can be "word", "sentence", or "passage"
+        "split_length": 1000,
+    }
+
+    parameters["retriever_type"] = "bm25"
+    pipelines.retriever_reader(parameters, elasticsearch_hostname = "localhost",
+            elasticsearch_port = "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever_reader")
+
+    parameters["retriever_type"] = "sbert"
+    pipelines.retriever_reader(parameters, elasticsearch_hostname = "localhost",
+            elasticsearch_port = "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever_reader")
+
+    parameters["retriever_type"] = "dpr"
+    pipelines.retriever_reader(parameters, elasticsearch_hostname = "localhost",
+            elasticsearch_port = "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever_reader")
+
+    parameters["retriever_type"] = "title"
+    pipelines.retriever_reader(parameters, elasticsearch_hostname = "localhost",
+            elasticsearch_port = "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever_reader")
+
+    parameters["retriever_type"] = "title_bm25"
+    pipelines.retriever_reader(parameters, elasticsearch_hostname = "localhost",
+            elasticsearch_port = "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever_reader")
+
+    parameters["retriever_type"] = "hot_reader"
+    pipelines.retriever_reader(parameters, elasticsearch_hostname = "localhost",
+            elasticsearch_port = "9200", gpu_id = -1,
+            yaml_dir_prefix = "output/test/pipelines/retriever_reader")


### PR DESCRIPTION
## Reference to a related issue

Targetting #39 

Depends on #150 

## Why is the change needed

To reduce discrepancy between the pipelines we evaluate in R&D and those deployed in production, we want to directly generate YAML files from the pipeline evaluated so that they can be used directly in prod.

This PR enables YAML generation of all the pipelines evaluated. All pipeline that are run through the scripts `src/evaluation/retriever_reader/retriever_reader_eval_squad.py` and `src/evaluation/retriever/retriever_eval_squad.py` are exported to YAML and loaded back from it before being evaluated. The YAML files are written to `output/pipelines/…`. Additionnally the former scripts stores the YAML pipeline on the mlflow server. See for example the artifact `pipelines.yaml` in https://datascience.etalab.studio/mlflow/#/experiments/20/runs/9b99bad55f6d435ebb45e524063054e7

There are still significant discrepancies between the pipelines used in `src/evaluation/…` and the pipelines used in prod and defined in `clients/*/pipelines.yaml`.
- the pipelines that are used in prod are different than those defined in `src/evaluation/…` and we still need to define pipelines that are consistent with those used in production,
- the pipelines use for evaluation rely on evaluation nodes that must not be present in the production pipeline (although those nodes *should* not have any impact on the pipeline behaviour),
- some pipeline components used in production (LabelElasticsearchRetriever) would make it impossible to evaluate the pipeline as is: it's score during evaluation would be perfect.

## Description of the change

Add systematic export of the pipeline to YAML and load back before running the pipeline for evaluation.

Add code in the custom pipeline components to enable YAML export.

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
