### PR TITLE
fix: deployments -> set rights only on group and others, not on user

### DIFF
--- a/clients/cnil/pipelines.yaml
+++ b/clients/cnil/pipelines.yaml
@@ -68,7 +68,7 @@ components:    # define all the building-blocks for Pipeline
     params:
       host: elasticsearch
       index: label_elasticsearch
-      embedding_dim: 512
+      embedding_dim: 768
       search_fields: [ question ]
       create_index: False
       embedding_field: emb

--- a/clients/dila/pipelines.yaml
+++ b/clients/dila/pipelines.yaml
@@ -68,7 +68,7 @@ components:    # define all the building-blocks for Pipeline
     params:
       host: elasticsearch
       index: label_elasticsearch
-      embedding_dim: 512
+      embedding_dim: 768
       search_fields: [ question ]
       create_index: False
       embedding_field: emb

--- a/deployment/roles/haystack/tasks/main.yml
+++ b/deployment/roles/haystack/tasks/main.yml
@@ -24,7 +24,7 @@
   file:
     path: "{{ client_installation_directory }}"
     group: "piaf-deployment"
-    mode: u=rwx,g=rwx,o=rx
+    mode: g=rwx,o=rx
     state: directory
     recurse: yes
 - name: "{{ client }} | copy custom_component.py"
@@ -77,3 +77,10 @@
   community.docker.docker_compose:
     project_src: "{{ client_installation_directory }}/"
     build: yes
+- name: "{{ client }} | change group ownership (https://github.com/ansible/ansible/issues/51601)"
+  file:
+    path: "{{ client_installation_directory }}"
+    group: "piaf-deployment"
+    mode: g=rwx,o=rx
+    state: directory
+    recurse: yes


### PR DESCRIPTION
## Reference to a related issue

## Why is the change needed
This is an annoying issue.

## Description of the change
We don't try to recursively set the user rights anymore, only the group (piaf-deployment) and others.

## (Optionnal) Description or justification of specific technical choices that were made

## @mentions of the persons responsible for reviewing 
